### PR TITLE
SEARCH-996 Update solr and alfresco-solrclient.

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -69,6 +69,25 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>delete-solr.xml</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target name="Delete Apache solr.xml config files">
+                                <delete>
+                                    <fileset dir="${project.build.directory}" includes="**/solr.xml" />
+                                </delete>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -50,28 +50,28 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>unpack-solr-war</id>
                         <phase>validate</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.apache.solr</groupId>
-                                    <artifactId>solr</artifactId>
-                                    <version>${solr.version}</version>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <excludes>**/*solr.xml</excludes>
-                                </artifactItem>
-                            </artifactItems>
+                            <url>${solr.zip}</url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
                     <execution>
                         <id>unpack-solr-config</id>
                         <phase>validate</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,10 @@
     <packaging>pom</packaging>
     <name>Alfresco Solr Search parent</name>
     <properties>
-        <solr.version>6.6.0</solr.version>
-        <alfresco-solrclient.version>6.5</alfresco-solrclient.version>
+        <solr.version>6.6.5</solr.version>
+        <alfresco-solrclient.version>6.7</alfresco-solrclient.version>
+        <!-- The location to download the solr zip file from. -->
+        <solr.zip>https://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.zip</solr.zip>
     </properties>
     <distributionManagement>
         <repository>


### PR DESCRIPTION
Update to Solr 6.6.5 and alfresco-solrclient 6.7 (which brings in
alfresco-datamodel 6.25).  This should fix several vulnerabilities
flagged by Whitesource.

Create build config to allow specifying the URL to download the solr
zip file from (in case we need to provide a patched version).