### PR TITLE
SEARCH-1003 Fix a couple of issues raised by Sonar.

### DIFF
--- a/alfresco-search/pom.xml
+++ b/alfresco-search/pom.xml
@@ -94,8 +94,8 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/alfresco-search/src/main/java/org/alfresco/solr/AlfrescoCoreAdminHandler.java
+++ b/alfresco-search/src/main/java/org/alfresco/solr/AlfrescoCoreAdminHandler.java
@@ -783,27 +783,16 @@ public class AlfrescoCoreAdminHandler extends CoreAdminHandler
         {
             throw new AlfrescoRuntimeException("No txid parameter set");
         }
+        if (cname == null)
+        {
+            throw new AlfrescoRuntimeException("No cname parameter set");
+        }
 
-        if (cname != null)
-        {
-            MetadataTracker tracker = trackerRegistry.getTrackerForCore(cname, MetadataTracker.class);
-            Long txid = Long.valueOf(params.get(ARG_TXID));
-            NamedList<Object> report = new SimpleOrderedMap<Object>();
-            report.add(cname, buildTxReport(getTrackerRegistry(), informationServers.get(cname), cname, tracker, txid));
-            rsp.add("report", report);
-        }
-        else
-        {
-            Long txid = Long.valueOf(params.get(ARG_TXID));
-            NamedList<Object> report = new SimpleOrderedMap<Object>();
-            for (String coreName : trackerRegistry.getCoreNames())
-            {
-                MetadataTracker tracker = trackerRegistry.getTrackerForCore(cname,
-                            MetadataTracker.class);
-                report.add(coreName, buildTxReport(getTrackerRegistry(), informationServers.get(coreName), coreName, tracker, txid));
-            }
-            rsp.add("report", report);
-        }
+        MetadataTracker tracker = trackerRegistry.getTrackerForCore(cname, MetadataTracker.class);
+        Long txid = Long.valueOf(params.get(ARG_TXID));
+        NamedList<Object> report = new SimpleOrderedMap<Object>();
+        report.add(cname, buildTxReport(getTrackerRegistry(), informationServers.get(cname), cname, tracker, txid));
+        rsp.add("report", report);
     }
 
     private void actionACLTXREPORT(SolrQueryResponse rsp, SolrParams params, String cname)

--- a/alfresco-search/src/main/java/org/alfresco/solr/AlfrescoCoreAdminHandler.java
+++ b/alfresco-search/src/main/java/org/alfresco/solr/AlfrescoCoreAdminHandler.java
@@ -85,7 +85,7 @@ public class AlfrescoCoreAdminHandler extends CoreAdminHandler
     protected static final Logger log = LoggerFactory.getLogger(AlfrescoCoreAdminHandler.class);
     
     private static final String ARG_ACLTXID = "acltxid";
-    private static final String ARG_TXID = "txid";
+    protected static final String ARG_TXID = "txid";
     private static final String ARG_ACLID = "aclid";
     private static final String ARG_NODEID = "nodeid";
     private static final String ARG_QUERY = "query";
@@ -1207,6 +1207,11 @@ public class AlfrescoCoreAdminHandler extends CoreAdminHandler
     public TrackerRegistry getTrackerRegistry()
     {
         return trackerRegistry;
+    }
+
+    protected void setTrackerRegistry(TrackerRegistry trackerRegistry)
+    {
+        this.trackerRegistry = trackerRegistry;
     }
 
     public SolrTrackerScheduler getScheduler()

--- a/alfresco-search/src/main/java/org/apache/solr/handler/component/AlfrescoLukeRequestHandler.java
+++ b/alfresco-search/src/main/java/org/apache/solr/handler/component/AlfrescoLukeRequestHandler.java
@@ -461,19 +461,14 @@ public class AlfrescoLukeRequestHandler extends RequestHandlerBase {
 	// to do it this way.
 	private static Document getFirstLiveDoc(Terms terms, LeafReader reader)
 			throws IOException {
-		PostingsEnum postingsEnum = null;
 		TermsEnum termsEnum = terms.iterator();
-		BytesRef text;
 		// Deal with the chance that the first bunch of terms are in deleted
 		// documents. Is there a better way?
-		for (int idx = 0; idx < 1000 && postingsEnum == null; ++idx) {
-			text = termsEnum.next();
-			if (text == null) { // Ran off the end of the terms enum without
-								// finding any live docs with that field in
-								// them.
+		for (int idx = 0; idx < 1000; ++idx) {
+			if (termsEnum.next() == null) { // Ran off the end of the terms enum without finding any live docs with that field in them.
 				return null;
 			}
-			postingsEnum = termsEnum.postings(postingsEnum, PostingsEnum.NONE);
+			PostingsEnum postingsEnum = termsEnum.postings(null, PostingsEnum.NONE);
 			final Bits liveDocs = reader.getLiveDocs();
 			if (postingsEnum.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
 				if (liveDocs != null && liveDocs.get(postingsEnum.docID())) {

--- a/alfresco-search/src/main/java/org/apache/solr/handler/component/AlfrescoLukeRequestHandler.java
+++ b/alfresco-search/src/main/java/org/apache/solr/handler/component/AlfrescoLukeRequestHandler.java
@@ -462,22 +462,16 @@ public class AlfrescoLukeRequestHandler extends RequestHandlerBase {
 	private static Document getFirstLiveDoc(Terms terms, LeafReader reader)
 			throws IOException {
 		TermsEnum termsEnum = terms.iterator();
-		// Deal with the chance that the first bunch of terms are in deleted
-		// documents. Is there a better way?
-		for (int idx = 0; idx < 1000; ++idx) {
-			if (termsEnum.next() == null) { // Ran off the end of the terms enum without finding any live docs with that field in them.
-				return null;
-			}
-			PostingsEnum postingsEnum = termsEnum.postings(null, PostingsEnum.NONE);
-			final Bits liveDocs = reader.getLiveDocs();
-			if (postingsEnum.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-				if (liveDocs != null && liveDocs.get(postingsEnum.docID())) {
-					continue;
-				}
-				return reader.document(postingsEnum.docID());
-			}
+		if (termsEnum.next() == null) { // Ran off the end of the terms enum without finding any live docs with that field in them.
+			return null;
 		}
-		return null;
+		PostingsEnum postingsEnum = termsEnum.postings(null, PostingsEnum.NONE);
+		final Bits liveDocs = reader.getLiveDocs();
+		if (postingsEnum.nextDoc() == DocIdSetIterator.NO_MORE_DOCS
+				|| (liveDocs != null && liveDocs.get(postingsEnum.docID()))) {
+			return null;
+		}
+		return reader.document(postingsEnum.docID());
 	}
 
 	/**

--- a/alfresco-search/src/main/java/org/apache/solr/handler/component/AlfrescoLukeRequestHandler.java
+++ b/alfresco-search/src/main/java/org/apache/solr/handler/component/AlfrescoLukeRequestHandler.java
@@ -459,7 +459,7 @@ public class AlfrescoLukeRequestHandler extends RequestHandlerBase {
 	// Just get a document with the term in it, the first one will do!
 	// Is there a better way to do this? Shouldn't actually be very costly
 	// to do it this way.
-	private static Document getFirstLiveDoc(Terms terms, LeafReader reader)
+	protected static Document getFirstLiveDoc(Terms terms, LeafReader reader)
 			throws IOException {
 		TermsEnum termsEnum = terms.iterator();
 		if (termsEnum.next() == null) { // Ran off the end of the terms enum without finding any live docs with that field in them.

--- a/alfresco-search/src/test/java/org/alfresco/solr/AlfrescoCoreAdminHandlerTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/AlfrescoCoreAdminHandlerTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.alfresco.solr;
+
+import static com.google.common.collect.Sets.newHashSet;
+
+import static org.alfresco.solr.AlfrescoCoreAdminHandler.ARG_TXID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.alfresco.solr.adapters.IOpenBitSet;
+import org.alfresco.solr.tracker.AclTracker;
+import org.alfresco.solr.tracker.IndexHealthReport;
+import org.alfresco.solr.tracker.MetadataTracker;
+import org.alfresco.solr.tracker.TrackerRegistry;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.params.CoreAdminParams;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Unit tests for {@link org.alfresco.solr.AlfrescoCoreAdminHandler}. */
+@RunWith(MockitoJUnitRunner.class)
+public class AlfrescoCoreAdminHandlerTest
+{
+    /** The string representing a transaction report. */
+    private static final String TXREPORT = "TXREPORT";
+    /** A transaction id. */
+    private static final String TX_ID = "123";
+    /** A core name. */
+    private static final String CORE_NAME = "CORE_NAME";
+
+    /** The class under test. */
+    @InjectMocks
+    private AlfrescoCoreAdminHandler alfrescoCoreAdminHandler;
+    @Mock
+    private TrackerRegistry trackerRegistry;
+    @Mock
+    private AclTracker aclTracker;
+    @Mock
+    private MetadataTracker metadataTracker;
+    @Mock
+    private IndexHealthReport indexHealthReport;
+    @Mock
+    private IndexHealthReport metaReport;
+    @Mock
+    private IOpenBitSet iOpenBitSet;
+    @Mock
+    private TrackerState trackerState;
+    @Mock
+    private InformationServer informationServer;
+    @Mock
+    private SolrQueryRequest req;
+    @Mock
+    private SolrQueryResponse rsp;
+    @Mock
+    private SolrParams params;
+
+    @Before
+    public void setUp()
+    {
+        // Wire the mocks into the class under test.
+        alfrescoCoreAdminHandler.setTrackerRegistry(trackerRegistry);
+        alfrescoCoreAdminHandler.getInformationServers().put(CORE_NAME, informationServer);
+
+        when(req.getParams()).thenReturn(params);
+        when(trackerRegistry.getCoreNames()).thenReturn(newHashSet(CORE_NAME));
+        // Requesting the tracker with a null core name throws a NPE.
+        when(trackerRegistry.getTrackerForCore(eq(null), any(Class.class))).thenThrow(NullPointerException.class);
+    }
+
+    /** Check that a transaction report can be generated. */
+    @Test
+    public void handleCustomActionTXReportSuccess() throws Exception
+    {
+        // Set up the parameters being passed in.
+        when(params.get(CoreAdminParams.ACTION)).thenReturn(TXREPORT);
+        when(params.get(CoreAdminParams.CORE)).thenReturn(CORE_NAME);
+        when(params.get(ARG_TXID)).thenReturn(TX_ID);
+        // Set up the mock ACL tracker.
+        when(trackerRegistry.getTrackerForCore(CORE_NAME, AclTracker.class)).thenReturn(aclTracker);
+        when(aclTracker.checkIndex(Long.valueOf(TX_ID), 0L, null, null)).thenReturn(indexHealthReport);
+        when(indexHealthReport.getDuplicatedAclTxInIndex()).thenReturn(iOpenBitSet);
+        when(indexHealthReport.getAclTxInIndexButNotInDb()).thenReturn(iOpenBitSet);
+        when(indexHealthReport.getMissingAclTxFromIndex()).thenReturn(iOpenBitSet);
+        when(aclTracker.getTrackerState()).thenReturn(trackerState);
+        // Set up the mock metadata tracker.
+        when(trackerRegistry.getTrackerForCore(CORE_NAME, MetadataTracker.class)).thenReturn(metadataTracker);
+        when(metadataTracker.checkIndex(Long.valueOf(TX_ID), 0L, null, null)).thenReturn(metaReport);
+        when(metaReport.getDuplicatedTxInIndex()).thenReturn(iOpenBitSet);
+        when(metaReport.getTxInIndexButNotInDb()).thenReturn(iOpenBitSet);
+        when(metaReport.getMissingTxFromIndex()).thenReturn(iOpenBitSet);
+        when(metaReport.getDuplicatedLeafInIndex()).thenReturn(iOpenBitSet);
+        when(metaReport.getDuplicatedErrorInIndex()).thenReturn(iOpenBitSet);
+        when(metaReport.getDuplicatedUnindexedInIndex()).thenReturn(iOpenBitSet);
+        when(metadataTracker.getTrackerState()).thenReturn(trackerState);
+
+        // Call the method under test.
+        alfrescoCoreAdminHandler.handleCustomAction(req, rsp);
+
+        // Check that a report was generated (don't look at the contents of the report though).
+        verify(rsp).add(eq("report"), any(NamedList.class));
+    }
+
+    /** Check that when the transaction id is missing we get an exception. */
+    @Test(expected = SolrException.class)
+    public void handleCustomActionTXReportMissingTXId()
+    {
+        when(params.get(CoreAdminParams.ACTION)).thenReturn(TXREPORT);
+        when(params.get(ARG_TXID)).thenReturn(null);
+
+        alfrescoCoreAdminHandler.handleCustomAction(req, rsp);
+
+        verify(rsp, never()).add(anyString(), any());
+    }
+
+    /** Check that when the core name is missing we get an exception. */
+    @Test(expected = SolrException.class)
+    public void handleCustomActionTXReportMissingCoreName()
+    {
+        when(params.get(CoreAdminParams.ACTION)).thenReturn(TXREPORT);
+        when(params.get(CoreAdminParams.CORE)).thenReturn(null);
+        when(params.get(ARG_TXID)).thenReturn(TX_ID);
+
+        alfrescoCoreAdminHandler.handleCustomAction(req, rsp);
+
+        verify(rsp, never()).add(anyString(), any());
+    }
+
+    /** Check that when an unknown action is provided we don't generate a report. */
+    @Test(expected = SolrException.class)
+    public void handleCustomActionUnknownAction()
+    {
+        when(params.get(CoreAdminParams.ACTION)).thenReturn("Unknown");
+
+        alfrescoCoreAdminHandler.handleCustomAction(req, rsp);
+
+        verify(rsp, never()).add(anyString(), any());
+    }
+
+    /** Check that when the action is missing we don't generate a report. */
+    @Test(expected = SolrException.class)
+    public void handleCustomActionMissingAction()
+    {
+        when(params.get(CoreAdminParams.ACTION)).thenReturn(null);
+
+        alfrescoCoreAdminHandler.handleCustomAction(req, rsp);
+
+        verify(rsp, never()).add(anyString(), any());
+    }
+}

--- a/alfresco-search/src/test/java/org/alfresco/solr/AlfrescoCoreAdminHandlerTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/AlfrescoCoreAdminHandlerTest.java
@@ -18,8 +18,6 @@
  */
 package org.alfresco.solr;
 
-import static com.google.common.collect.Sets.newHashSet;
-
 import static org.alfresco.solr.AlfrescoCoreAdminHandler.ARG_TXID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -91,9 +89,6 @@ public class AlfrescoCoreAdminHandlerTest
         alfrescoCoreAdminHandler.getInformationServers().put(CORE_NAME, informationServer);
 
         when(req.getParams()).thenReturn(params);
-        when(trackerRegistry.getCoreNames()).thenReturn(newHashSet(CORE_NAME));
-        // Requesting the tracker with a null core name throws a NPE.
-        when(trackerRegistry.getTrackerForCore(eq(null), any(Class.class))).thenThrow(NullPointerException.class);
     }
 
     /** Check that a transaction report can be generated. */

--- a/alfresco-search/src/test/java/org/alfresco/solr/component/TempFileWarningLoggerTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/component/TempFileWarningLoggerTest.java
@@ -21,7 +21,12 @@ package org.alfresco.solr.component;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,17 +35,11 @@ import java.nio.file.Paths;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
-
-@RunWith(MockitoJUnitRunner.class)
 public class TempFileWarningLoggerTest
 {
-    private @Mock Logger log;
+    private Logger log;
     private Path path;
     
     @Before
@@ -48,8 +47,10 @@ public class TempFileWarningLoggerTest
     {
         path = Paths.get(System.getProperty("java.io.tmpdir"));
         
-        // Simulate warn-level logging
-        Mockito.when(log.isWarnEnabled()).thenReturn(true);
+        // Simulate warn-level logging (Although currently we only log debug messages).
+        log = mock(Logger.class, withSettings().lenient());
+        when(log.isWarnEnabled()).thenReturn(true);
+        when(log.isErrorEnabled()).thenReturn(true);
     }
     
     @Test
@@ -84,7 +85,7 @@ public class TempFileWarningLoggerTest
             
             assertTrue("Should have found matching files", found);
             // Should be a warn-level log message.
-            Mockito.verify(log, never()).warn(Mockito.anyString());
+            verify(log, never()).warn(anyString());
         }
         finally
         {
@@ -112,7 +113,7 @@ public class TempFileWarningLoggerTest
         
         assertFalse("Should NOT have found matching file", found);
         // Should be no warn-level log message.
-        Mockito.verify(log, Mockito.never()).warn(Mockito.anyString());
+        verify(log, never()).warn(anyString());
     }    
     
     @Test

--- a/alfresco-search/src/test/java/org/alfresco/solr/tracker/TrackerRegistryTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/tracker/TrackerRegistryTest.java
@@ -56,7 +56,7 @@ public class TrackerRegistryTest
         registerTrackers(CORE_NAME);
     }
 
-    
+
     @Test
     public void testGetCoreNames()
     {

--- a/alfresco-search/src/test/java/org/apache/solr/handler/component/AlfrescoLukeRequestHandlerTest.java
+++ b/alfresco-search/src/test/java/org/apache/solr/handler/component/AlfrescoLukeRequestHandlerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2005-2013 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.apache.solr.handler.component;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.IOException;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+
+/**
+ * Unit tests for the {@link AlfrescoLukeRequestHandler}.
+ */
+public class AlfrescoLukeRequestHandlerTest
+{
+    /** The reference to text for a search term. */
+    private static final BytesRef TERM_TEXT = new BytesRef("TermText");
+    /** A document id. */
+    private static final int DOC_ID = 123;
+
+    @Mock
+    private Terms mockTerms;
+    @Mock
+    private TermsEnum mockTermsEnum;
+    @Mock
+    private PostingsEnum mockPostingsEnum;
+    @Mock
+    private LeafReader mockReader;
+    @Mock
+    private Bits mockBits;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        initMocks(this);
+
+        // Link up the mocks.
+        when(mockTerms.iterator()).thenReturn(mockTermsEnum);
+        when(mockTermsEnum.postings(null, PostingsEnum.NONE)).thenReturn(mockPostingsEnum);
+    }
+
+    /** Check that we can find a live document for a set of search terms. */
+    @Test
+    public void testFindLiveDoc() throws IOException
+    {
+        // Set up the term to return the document.
+        when(mockTermsEnum.next()).thenReturn(TERM_TEXT);
+        when(mockPostingsEnum.nextDoc()).thenReturn(DOC_ID);
+        when(mockPostingsEnum.docID()).thenReturn(DOC_ID);
+        // Set up the leaf reader to be able to return a document.
+        when(mockReader.getLiveDocs()).thenReturn(mockBits);
+        Document document = new Document();
+        when(mockReader.document(DOC_ID)).thenReturn(document);
+
+        // Call the method under test.
+        Document firstLiveDoc = AlfrescoLukeRequestHandler.getFirstLiveDoc(mockTerms, mockReader);
+
+        // We need to ensure that the PostingsEnum is initialised before use by a call to nextDoc.
+        InOrder postingsInitialisedCheck = inOrder(mockPostingsEnum);
+        postingsInitialisedCheck.verify(mockPostingsEnum).nextDoc();
+        postingsInitialisedCheck.verify(mockPostingsEnum, atLeastOnce()).docID();
+        // Check the returned value.
+        assertEquals("Expected to find the document.", document, firstLiveDoc);
+    }
+
+    /** Check that we can find a live document for a set of search terms when no documents have been deleted. */
+    @Test
+    public void testFindLiveDocWithNoDeletedDocuments() throws IOException
+    {
+        // Set up the term to return the document.
+        when(mockTermsEnum.next()).thenReturn(TERM_TEXT);
+        when(mockPostingsEnum.nextDoc()).thenReturn(DOC_ID);
+        when(mockPostingsEnum.docID()).thenReturn(DOC_ID);
+        // Returning null indicates that there are no deleted documents.
+        when(mockReader.getLiveDocs()).thenReturn(null);
+        Document document = new Document();
+        when(mockReader.document(DOC_ID)).thenReturn(document);
+
+        // Call the method under test.
+        Document firstLiveDoc = AlfrescoLukeRequestHandler.getFirstLiveDoc(mockTerms, mockReader);
+
+        // We need to ensure that the PostingsEnum is initialised before use by a call to nextDoc.
+        InOrder postingsInitialisedCheck = inOrder(mockPostingsEnum);
+        postingsInitialisedCheck.verify(mockPostingsEnum).nextDoc();
+        postingsInitialisedCheck.verify(mockPostingsEnum, atLeastOnce()).docID();
+        // Check the returned value.
+        assertEquals("Expected to find the document.", document, firstLiveDoc);
+    }
+
+    /** Check that we can find a live document for a set of search terms when no documents have been deleted. */
+    @Test
+    public void testFindLiveDocWithNullTerm() throws IOException
+    {
+        // There are no search terms.
+        when(mockTermsEnum.next()).thenReturn(null);
+
+        // Call the method under test.
+        Document firstLiveDoc = AlfrescoLukeRequestHandler.getFirstLiveDoc(mockTerms, mockReader);
+
+        // Check the returned value.
+        assertNull("Expected no document to be returned.", firstLiveDoc);
+    }
+
+    /** Check the behaviour when the first document found was deleted. */
+    @Test
+    public void testDocWasDeleted() throws IOException
+    {
+        // Set up the term to return the document.
+        when(mockTermsEnum.next()).thenReturn(TERM_TEXT);
+        when(mockPostingsEnum.nextDoc()).thenReturn(DOC_ID);
+        when(mockPostingsEnum.docID()).thenReturn(DOC_ID);
+        // Set up the leaf reader to return a deleted document.
+        when(mockReader.getLiveDocs()).thenReturn(mockBits);
+        Document document = new Document();
+        when(mockReader.document(DOC_ID)).thenReturn(document);
+        when(mockBits.get(DOC_ID)).thenReturn(true);
+
+        // Call the method under test.
+        Document firstLiveDoc = AlfrescoLukeRequestHandler.getFirstLiveDoc(mockTerms, mockReader);
+
+        // Check the returned value.
+        assertNull("Expected no document to be returned.", firstLiveDoc);
+    }
+
+    /** Check the behaviour when there are no more documents matching the terms. */
+    @Test
+    public void testNoMoreDocs() throws IOException
+    {
+        // There is a search term but no matching documents.
+        when(mockTermsEnum.next()).thenReturn(TERM_TEXT);
+        when(mockPostingsEnum.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+
+        // Call the method under test.
+        Document firstLiveDoc = AlfrescoLukeRequestHandler.getFirstLiveDoc(mockTerms, mockReader);
+
+        // Check the returned value.
+        assertNull("Expected no document to be returned.", firstLiveDoc);
+    }
+}

--- a/alfresco-search/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/alfresco-search/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Replace some code that throws a NullPointerException with code to explicitly throw
an AlfrescoRuntimeException if the core name is not passed when creating the
transaction report.

Simplify the logic when getting the first live doc for a search term by not reusing
the postings iterator (nb. It wasn't being reused anyway as we always passed null).