### PR TITLE
[MNT-19456] intermittent test fixed removing unnecessary docs

### DIFF
--- a/alfresco-search/src/test/java/org/alfresco/solr/query/DistributedAlfrescoSolrFacetingTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/query/DistributedAlfrescoSolrFacetingTest.java
@@ -72,7 +72,7 @@ import static org.hamcrest.core.Is.is;
         putHandleDefaults();
 
         QueryResponse queryResponse = query(getDefaultTestClient(), true, jsonQuery,
-            params("qt", "/afts", "shards.qt", "/afts", "start", "0", "rows", "100", "fl", "score,id", "facet", "true",
+            params("qt", "/afts", "shards.qt", "/afts", "start", "0", "rows", "0", "fl", "score,id", "facet", "true",
                 "facet.field", "{http://www.alfresco.org/model/content/1.0}content", "facet.limit", "2",
                 "facet.overrequest.count", "0", "facet.overrequest.ratio", "1"));
 


### PR DESCRIPTION
The reason the test was intermittent is because given the query in the test: **suggest:a** ,
Two documents from different shards have exact same score (id=1, id=4).
Being the documents in the response aggregated, their order will not be deterministic, due to the aggregator shard chosen mostly and other internal factors.

Being the test facet inherent, the actual returned docs are irrelevant, so asking for 0 rows should resolve the intermittent phenomenon.
The number of returned docs doesn't affect the documents found and the faceting calculations.
It just regulates the number of documents returned to the user.