### PR TITLE
SEARCH-1286: datatype casting errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>Alfresco Solr Search parent</name>
     <properties>
         <solr.version>6.6.5</solr.version>
-        <alfresco-solrclient.version>6.10</alfresco-solrclient.version>
+        <alfresco-solrclient.version>6.11</alfresco-solrclient.version>
         <!-- The location to download the solr zip file from. -->
         <!-- <solr.zip>https://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.zip</solr.zip> -->
         <!-- Solr startup scripts do not work with any Java version higher than 9 so the scripts have been patched -->

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>Alfresco Solr Search parent</name>
     <properties>
         <solr.version>6.6.5</solr.version>
-        <alfresco-solrclient.version>6.11</alfresco-solrclient.version>
+        <alfresco-solrclient.version>6.12</alfresco-solrclient.version>
         <!-- The location to download the solr zip file from. -->
         <!-- <solr.zip>https://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.zip</solr.zip> -->
         <!-- Solr startup scripts do not work with any Java version higher than 9 so the scripts have been patched -->


### PR DESCRIPTION
Hi @tunaaksoy this is the PR which includes the dependency version of alfresco-solrclient.
Bamboo is failing [1] but I don't think it is related with that change, it is a failure in the TAS-REST-API:

```
java.lang.AssertionError: expected [true] but found [false]
	at org.alfresco.rest.search.FingerPrintTest.searchSimilar(FingerPrintTest.java:116)

java.lang.AssertionError: expected [true] but found [false]
	at org.alfresco.rest.search.FingerPrintTest.searchSimilar67Percent(FingerPrintTest.java:144)```

Not sure how to proceed. I will try to re-run the build in order to see if that is an intermittent stuff.

-----   
[1] https://bamboo.alfresco.com/bamboo/browse/SAD-SOLRSONDOCK82-TRT-2