### PR TITLE
[ Search 1280 ] SolrInformationServer refactor

### DIFF
--- a/alfresco-search/src/main/java/org/alfresco/solr/logging/Log.java
+++ b/alfresco-search/src/main/java/org/alfresco/solr/logging/Log.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.alfresco.solr.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Logging utility.
+ * It is a simple wrapper around a logger implementation, which allows a more concise code.
+ *
+ * @author Andrea Gazzarini
+ * @since 1.3
+ */
+public class Log
+{
+    private final Logger logger;
+
+    public Log(Class owner)
+    {
+        this.logger = LoggerFactory.getLogger(owner);
+    }
+
+    /**
+     * Logs a given message with DEBUG level.
+     *
+     * @param message the message template (with placeholders)
+     * @param params the optional array of values.
+     */
+    public void debug(String message, Object ... params)
+    {
+        if(logger.isDebugEnabled())
+        {
+            logger.debug(message, params);
+        }
+    }
+
+    /**
+     * Logs a given message with WARNING level.
+     *
+     * @param message the message template (with placeholders)
+     * @param params the optional array of values.
+     */
+    public void warning(String message, Object ... params)
+    {
+        if(logger.isWarnEnabled())
+        {
+            logger.warn(message, params);
+        }
+    }
+
+    /**
+     * Logs a given message with ERROR level.
+     *
+     * @param message the message template (with placeholders)
+     * @param params the optional array of values.
+     */
+    public void error(String message, Object ... params)
+    {
+        logger.error(message, params);
+    }
+
+    /**
+     * Logs a given message with INFO level.
+     *
+     * @param message the message template (with placeholders)
+     * @param params the optional array of values.
+     */
+    public void info(String message, Object ... params)
+    {
+        logger.info(message, params);
+    }
+}

--- a/alfresco-search/src/test/java/org/alfresco/solr/SolrInformationServerTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/SolrInformationServerTest.java
@@ -20,29 +20,129 @@
 package org.alfresco.solr;
 
 import java.io.IOException;
+import java.util.Properties;
 
+import org.alfresco.solr.client.SOLRAPIClient;
+import org.alfresco.solr.content.SolrContentStore;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.core.SolrResourceLoader;
+import org.apache.solr.request.LocalSolrQueryRequest;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.request.SolrRequestHandler;
+import org.apache.solr.response.SolrQueryResponse;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link SolrInformationServer} class.
  *
  * @author Matt Ward
+ * @author Andrea Gazzarini
  */
-/*
 @RunWith(MockitoJUnitRunner.class)
-*/
 public class SolrInformationServerTest //extends SolrCoreTestBase
-{ /*
+{
     private SolrInformationServer infoServer;
+
     @Mock
-    Cloud cloud;
+    private AlfrescoCoreAdminHandler adminHandler;
+
+    @Mock
+    private SolrResourceLoader resourceLoader;
+
+    @Mock
+    private SolrCore core;
+
+    @Mock
+    private SOLRAPIClient client;
+
+    @Mock
+    private SolrContentStore contentStore;
+
+    @Mock
+    private SolrRequestHandler handler;
+
+    @Mock
+    private SolrQueryResponse response;
+
+    private SolrQueryRequest request;
 
     @Before
-    public void setUp() throws Exception
+    public void setUp()
     {
-        infoServer = new SolrInformationServer(adminHandler, core, solrAPIClient, solrContentStore);
+        when(core.getResourceLoader()).thenReturn(resourceLoader);
+        when(resourceLoader.getCoreProperties()).thenReturn(new Properties());
+        infoServer = new SolrInformationServer(adminHandler, core, client, contentStore)
+        {
+            // @Override
+            SolrQueryResponse newSolrQueryResponse()
+            {
+                return response;
+            }
+        };
+
+        request = infoServer.newSolrQueryRequest();
     }
-*/
+
+    @Test
+    public void testGetStateOk()
+    {
+        String id = String.valueOf(System.currentTimeMillis());
+
+        SolrDocument state = new SolrDocument();
+
+        SimpleOrderedMap responseContent = new SimpleOrderedMap<>();
+        responseContent.add(SolrInformationServer.RESPONSE_DEFAULT_ID, state);
+
+        when(response.getValues()).thenReturn(responseContent);
+        when(core.getRequestHandler(SolrInformationServer.REQUEST_HANDLER_GET)).thenReturn(handler);
+
+        SolrDocument document = infoServer.getState(core, request, id);
+
+        assertEquals(id, request.getParams().get(CommonParams.ID));
+        verify(core).getRequestHandler(SolrInformationServer.REQUEST_HANDLER_GET);
+        verify(response).getValues();
+
+        assertSame(state, document);
+    }
+
+    /**
+     * GetState returns null in case the given id doesn't correspond to an existing state document.
+     */
+    @Test
+    public void testGetStateWithStateNotFound_returnsNull()
+    {
+        String id = String.valueOf(System.currentTimeMillis());
+
+        SimpleOrderedMap responseContent = new SimpleOrderedMap<>();
+        responseContent.add(SolrInformationServer.RESPONSE_DEFAULT_ID, null);
+
+        when(response.getValues()).thenReturn(responseContent);
+        when(core.getRequestHandler(SolrInformationServer.REQUEST_HANDLER_GET)).thenReturn(handler);
+
+        SolrDocument document = infoServer.getState(core, request, id);
+
+        assertEquals(id, request.getParams().get(CommonParams.ID));
+        verify(core).getRequestHandler(SolrInformationServer.REQUEST_HANDLER_GET);
+        verify(response).getValues();
+
+        assertNull(document);
+    }
 
     @Test
     public void testIndexAcl() throws IOException


### PR DESCRIPTION
The PR contains a formal refactor of SolrInformationServer, including: 

- order and modifier (private, public) of member instances
- formatting rules (e.g. curly braces on new line, spaces) 
- private methods moved to the bottom
- unused members (methods / variables) removal
- constants (e.g. CommonParams.Q) instead of redundant literals
- unnecessary boxing / unboxing removal
- generics
- System.out removal
- a logger utility for isolating / removing conditional statements within the class
- compose methods for removing the most evident code duplications
- minimal unit test 

The PR will contain a lot of commits with a fine level of granularity, because after each change I executed the whole SearchServices test suite, in order to make sure everything was still working.  