### PR TITLE
[ SEARCH-1331 ] Added log4j in test/resources folder

### DIFF
--- a/alfresco-search/src/test/resources/log4j.xml
+++ b/alfresco-search/src/test/resources/log4j.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{ABSOLUTE} %t %-5p %30.30c %x - %m%n" />
+        </layout>
+    </appender>
+
+    <!-- ##### ALL ALFRESCO MESSAGES ##### -->
+    <!--
+        <category name="org.alfresco">
+            <priority value="DEBUG"/>
+        </category>
+    -->
+
+    <!-- ##### ALL SOLR MESSAGES ##### -->
+    <!--
+        <category name="org.apache.solr">
+            <priority value="INFO"/>
+        </category>
+    -->
+
+    <!-- ##### ONLY SOLR QUERIES ##### -->
+    <!--
+        <category name="org.apache.solr.core.SolrCore.Request">
+            <priority value="DEBUG"/>
+        </category>
+    -->
+
+    <root>
+        <priority value="ERROR"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</log4j:configuration>


### PR DESCRIPTION
The PR contains a log4j.xml file in test/resources folder with default settings (ALL ERRORS) and some predefined and commented section useful for debugging purposes (e.g. Solr queries, Alfresco messages) 