### PR TITLE
[ MNT-19456] solrclient version 6.13 reinserted (6.12 -> 6.13)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>Alfresco Solr Search parent</name>
     <properties>
         <solr.version>6.6.5</solr.version>
-        <alfresco-solrclient.version>6.12</alfresco-solrclient.version>
+        <alfresco-solrclient.version>6.13</alfresco-solrclient.version>
         <!-- The location to download the solr zip file from. -->
         <!-- <solr.zip>https://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.zip</solr.zip> -->
         <!-- Solr startup scripts do not work with any Java version higher than 9 so the scripts have been patched -->


### PR DESCRIPTION
The PR re-inserts the correct alfresco-solrclient dependency version which has been fixed for MNT-19456  