### PR TITLE
SEARCH-1322 Metadata tracker max transaction id

### DIFF
--- a/alfresco-search/src/main/java/org/alfresco/solr/tracker/MetadataTracker.java
+++ b/alfresco-search/src/main/java/org/alfresco/solr/tracker/MetadataTracker.java
@@ -240,7 +240,7 @@ public class MetadataTracker extends AbstractTracker implements Tracker
             state.setCheckedFirstTransactionTime(true);
             log.info("No transactions found - no verification required");
 
-            firstTransactions = client.getTransactions(null, 0L, null, 2000L, 1);
+            firstTransactions = client.getTransactions(null, 0L, null, Long.MAX_VALUE, 1);
             if (!firstTransactions.getTransactions().isEmpty())
             {
                 Transaction firstTransaction = firstTransactions.getTransactions().get(0);
@@ -252,7 +252,7 @@ public class MetadataTracker extends AbstractTracker implements Tracker
         
         if (!state.isCheckedFirstTransactionTime())
         {
-            firstTransactions = client.getTransactions(null, 0L, null, 2000L, 1);
+            firstTransactions = client.getTransactions(null, 0L, null, Long.MAX_VALUE, 1);
             if (!firstTransactions.getTransactions().isEmpty())
             {
                 Transaction firstTransaction = firstTransactions.getTransactions().get(0);
@@ -285,7 +285,7 @@ public class MetadataTracker extends AbstractTracker implements Tracker
         {
             if (firstTransactions == null)
             {
-                firstTransactions = client.getTransactions(null, 0L, null, 2000L, 1);
+                firstTransactions = client.getTransactions(null, 0L, null, Long.MAX_VALUE, 1);
             }
             
             setLastTxCommitTimeAndTxIdInTrackerState(firstTransactions, state);
@@ -1049,7 +1049,7 @@ public class MetadataTracker extends AbstractTracker implements Tracker
     {
         // DB TX Count
         long firstTransactionCommitTime = 0;
-        Transactions firstTransactions = client.getTransactions(null, 0L, null, 2000L, 1);
+        Transactions firstTransactions = client.getTransactions(null, 0L, null, Long.MAX_VALUE, 1);
         if(firstTransactions.getTransactions().size() > 0)
         {
             Transaction firstTransaction = firstTransactions.getTransactions().get(0);

--- a/alfresco-search/src/test/java/org/alfresco/solr/tracker/DistributedAlfrescoSolrTrackerRaceTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/tracker/DistributedAlfrescoSolrTrackerRaceTest.java
@@ -18,6 +18,12 @@
  */
 package org.alfresco.solr.tracker;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.alfresco.solr.AlfrescoSolrUtils.*;
+import static org.alfresco.solr.AlfrescoSolrUtils.getAclReaders;
+import static org.alfresco.solr.AlfrescoSolrUtils.list;
+
 import org.alfresco.solr.AbstractAlfrescoDistributedTest;
 import org.alfresco.repo.search.adaptor.lucene.QueryConstants;
 import org.alfresco.solr.client.*;
@@ -28,16 +34,8 @@ import org.apache.lucene.search.LegacyNumericRangeQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.client.solrj.response.QueryResponse;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static org.alfresco.solr.AlfrescoSolrUtils.*;
-import static org.alfresco.solr.AlfrescoSolrUtils.getAclReaders;
-import static org.alfresco.solr.AlfrescoSolrUtils.list;
-
-import java.util.List;
-import java.util.ArrayList;
 
 /**
  * @author Joel
@@ -55,20 +53,19 @@ public class DistributedAlfrescoSolrTrackerRaceTest extends AbstractAlfrescoDist
     {
         putHandleDefaults();
 
-
         AclChangeSet aclChangeSet = getAclChangeSet(1);
 
         Acl acl = getAcl(aclChangeSet);
         Acl acl2 = getAcl(aclChangeSet);
 
-        AclReaders aclReaders = getAclReaders(aclChangeSet, acl, list("joel"), list("phil"), null);
-        AclReaders aclReaders2 = getAclReaders(aclChangeSet, acl2, list("jim"), list("phil"), null);
+        AclReaders aclReaders = getAclReaders(aclChangeSet, acl, singletonList("joel"), singletonList("phil"), null);
+        AclReaders aclReaders2 = getAclReaders(aclChangeSet, acl2, singletonList("jim"), singletonList("phil"), null);
 
         Transaction txn = getTransaction(0, 2);
         long txnCommitTimeMs = txn.getCommitTimeMs();
 
-        //Subtract from the commit time to go beyond hole retention
-        long backdatedCommitTimeMs = txnCommitTimeMs-(4600000);
+        // Subtract from the commit time to go beyond hole retention
+        long backdatedCommitTimeMs = txnCommitTimeMs - 4600000;
         txn.setCommitTimeMs(backdatedCommitTimeMs);
 
         //Next create two nodes to update for the transaction
@@ -76,23 +73,16 @@ public class DistributedAlfrescoSolrTrackerRaceTest extends AbstractAlfrescoDist
         Node fileNode = getNode(txn, acl, Node.SolrApiNodeStatus.UPDATED);
         Node errorNode = getNode(txn, acl, Node.SolrApiNodeStatus.UPDATED);
 
-
-        //Next create the NodeMetaData for each node. TODO: Add more metadata
+        // Next, create the node metadata for each node.
+        // Note: the error node metadata will cause an exception.
         NodeMetaData folderMetaData = getNodeMetaData(folderNode, txn, acl, "mike", null, false);
         NodeMetaData fileMetaData   = getNodeMetaData(fileNode, txn, acl, "mike", ancestors(folderMetaData.getNodeRef()), false);
-        //The errorNodeMetaData will cause an exception.
         NodeMetaData errorMetaData   = getNodeMetaData(errorNode, txn, acl, "lisa", ancestors(folderMetaData.getNodeRef()), true);
 
-        //Index the transaction, nodes, and nodeMetaDatas.
-        //Note that the content is automatically created by the test framework.
-        indexTransaction(txn,
-            list(errorNode, folderNode, fileNode),
-            list(errorMetaData, folderMetaData, fileMetaData));
-
-
-        indexAclChangeSet(aclChangeSet,
-            list(acl, acl2),
-            list(aclReaders, aclReaders2));
+        // Index the transaction, nodes, and nodeMetaDatas.
+        // Note that the content is automatically created by the test framework.
+        indexTransaction(txn, asList(errorNode, folderNode, fileNode), asList(errorMetaData, folderMetaData, fileMetaData));
+        indexAclChangeSet(aclChangeSet, asList(acl, acl2), asList(aclReaders, aclReaders2));
 
         System.out.println(backdatedCommitTimeMs + ":" + txnCommitTimeMs);
 
@@ -109,7 +99,6 @@ public class DistributedAlfrescoSolrTrackerRaceTest extends AbstractAlfrescoDist
         waitForDocCountAllCores(new TermQuery(new Term(QueryConstants.FIELD_READER, "jim")), 1, 80000);
         waitForDocCount(new TermQuery(new Term("content@s___t@{http://www.alfresco.org/model/content/1.0}content", "world")), 2, 100000);
         waitForDocCount(new TermQuery(new Term("content@s___t@{http://www.alfresco.org/model/content/1.0}content", Long.toString(fileNode.getId()))), 1, 80000);
-
 
         //This will run the query on the control client and the cluster and compare the result.
         query(getDefaultTestClient(), true, "{\"locales\":[\"en\"], \"templates\": [{\"name\":\"t1\", \"template\":\"%cm:content\"}]}",

--- a/alfresco-search/src/test/resources/log4j.xml
+++ b/alfresco-search/src/test/resources/log4j.xml
@@ -9,11 +9,17 @@
 
     <!-- ##### ALL ALFRESCO MESSAGES ##### -->
     <!--
-        <category name="org.alfresco">
-            <priority value="DEBUG"/>
+        <category name="org.apache.solr">
+            <priority value="INFO"/>
         </category>
     -->
 
+    <!-- ##### METADATA TRACKER MESSAGES ##### -->
+    <!--
+        <category name="org.alfresco.solr.tracker.MetadataTracker">
+            <priority value="DEBUG"/>
+        </category>
+    -->
     <!-- ##### ALL SOLR MESSAGES ##### -->
     <!--
         <category name="org.apache.solr">


### PR DESCRIPTION
This PR contains: 

- A fix in _MetadataTracker_ which replaces a dummy value (2000L) used in MaxTransactionId parameter with a reasonable high value (Long.MAX_VALUE) which should act better as an "unbounded extreme"  
- a new commented category in the (test) logging configuration, for quickly enabling the metadata tracker messages
- better test coverage in DistributedAlfrescoSolrTrackerRaceTest
- some readability improvement in DistributedAlfrescoSolrTrackerRaceTest