### PR TITLE
MSP-208 make solr run as (configurable-at-build-time) user other than 1000

### DIFF
--- a/packaging/src/docker/Dockerfile
+++ b/packaging/src/docker/Dockerfile
@@ -8,10 +8,19 @@ ENV SOLR_ZIP ${project.build.finalName}.zip
 ENV LANG C.UTF-8
 ENV OPENSSL_VERSION 1.0.2k-8.el7
 
+ARG USERNAME=solr
+ARG USERID=33007
+
 COPY "$SOLR_ZIP" .
 
-RUN groupadd solr && useradd -s /bin/bash -g solr solr
 RUN set -x \
+   && useradd \
+        -c "Alfresco ${USERNAME}" \
+        -M \
+        -s "/bin/bash" \
+        -u "${USERID}" \
+        -o \
+        "${USERNAME}" \
    && yum update -y \
    && yum install -y unzip \
    && yum install -y lsof ca-certificates openssl-$OPENSSL_VERSION \
@@ -19,7 +28,7 @@ RUN set -x \
    && unzip "$SOLR_ZIP" -d /opt/ && rm "$SOLR_ZIP" \
    && mkdir -p $DIST_DIR/data \
    && mv $DIST_DIR/solrhome/alfrescoModels $DIST_DIR/data/ \
-   && chown -R solr:solr $DIST_DIR \
+   && chown -R ${USERNAME}:${USERNAME} $DIST_DIR \
    && echo '#Docker Setup' >> $DIST_DIR/solr.in.sh \
    && echo 'SOLR_OPTS="$SOLR_OPTS -Dsolr.data.dir.root=$DIST_DIR/data -Dsolr.solr.model.dir=$DIST_DIR/data/alfrescoModels"' >> $DIST_DIR/solr.in.sh
 
@@ -32,5 +41,5 @@ VOLUME $DIST_DIR/data
 VOLUME $DIST_DIR/solrhome
 
 EXPOSE 8983
-USER solr
+USER ${USERNAME}
 CMD $DIST_DIR/solr/bin/search_config_setup.sh "$DIST_DIR/solr/bin/solr start -f"


### PR DESCRIPTION
`useradd` on CentOS starts at `1000`. This maps to `ec2-user` which often has `sudo` rights on the host machine. I've picked a semi-random uid (`33007`) which is unique on trials.