### PR TITLE
SEARCH-1371: Always use LuceneVersion.LATEST

### DIFF
--- a/alfresco-search/src/main/java/org/alfresco/solr/AlfrescoSolrDataModel.java
+++ b/alfresco-search/src/main/java/org/alfresco/solr/AlfrescoSolrDataModel.java
@@ -1867,7 +1867,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
      public Solr4QueryParser getLuceneQueryParser(SearchParameters searchParameters, SolrQueryRequest req, FTSQueryParser.RerankPhase rerankPhase)
      {
          Analyzer analyzer =  req.getSchema().getQueryAnalyzer();
-         Solr4QueryParser parser = new Solr4QueryParser(req, Version.LUCENE_5_5_0, searchParameters.getDefaultFieldName(), analyzer, rerankPhase);
+         Solr4QueryParser parser = new Solr4QueryParser(req, Version.LATEST, searchParameters.getDefaultFieldName(), analyzer, rerankPhase);
          parser.setNamespacePrefixResolver(namespaceDAO);
          parser.setDictionaryService(getDictionaryService(CMISStrictDictionaryService.DEFAULT));
          parser.setTenantService(tenantService);

--- a/alfresco-search/src/main/java/org/alfresco/solr/query/Lucene4QueryBuilderContextSolrImpl.java
+++ b/alfresco-search/src/main/java/org/alfresco/solr/query/Lucene4QueryBuilderContextSolrImpl.java
@@ -61,7 +61,7 @@ public class Lucene4QueryBuilderContextSolrImpl implements LuceneQueryBuilderCon
     public Lucene4QueryBuilderContextSolrImpl(DictionaryService dictionaryService, NamespacePrefixResolver namespacePrefixResolver, TenantService tenantService,
             SearchParameters searchParameters, MLAnalysisMode defaultSearchMLAnalysisMode, SolrQueryRequest req, AlfrescoSolrDataModel model, FTSQueryParser.RerankPhase rerankPhase)
     {
-          lqp = new Solr4QueryParser(req, Version.LUCENE_5_5_0, searchParameters.getDefaultFieldName(), req.getSchema().getQueryAnalyzer(), rerankPhase);
+          lqp = new Solr4QueryParser(req, Version.LATEST, searchParameters.getDefaultFieldName(), req.getSchema().getQueryAnalyzer(), rerankPhase);
 //        lqp.setDefaultOperator(AbstractLuceneQueryParser.OR_OPERATOR);
         lqp.setDictionaryService(dictionaryService);
         lqp.setNamespacePrefixResolver(namespacePrefixResolver);

--- a/alfresco-search/src/main/java/org/apache/solr/handler/component/AlfrescoSearchHandler.java
+++ b/alfresco-search/src/main/java/org/apache/solr/handler/component/AlfrescoSearchHandler.java
@@ -476,7 +476,7 @@ public class AlfrescoSearchHandler extends RequestHandlerBase implements
 								// this behavior since it did not work this way
 								// prior to 5.1
 								if (req.getCore().getSolrConfig().luceneMatchVersion
-										.onOrAfter(Version.LUCENE_5_1_0)) {
+										.onOrAfter(Version.LATEST)) {
 									String reqPath = (String) req.getContext()
 											.get(PATH);
 									if (!"/select".equals(reqPath)) {

--- a/alfresco-search/src/main/resources/solr/instance/templates/aps/process/conf/solrconfig.xml
+++ b/alfresco-search/src/main/resources/solr/instance/templates/aps/process/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>4.9</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load an Jars
        identified and use them to resolve any "plugins" specified in

--- a/alfresco-search/src/main/resources/solr/instance/templates/aps/processDefinition/conf/solrconfig.xml
+++ b/alfresco-search/src/main/resources/solr/instance/templates/aps/processDefinition/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>4.9</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load an Jars
        identified and use them to resolve any "plugins" specified in

--- a/alfresco-search/src/main/resources/solr/instance/templates/aps/task/conf/solrconfig.xml
+++ b/alfresco-search/src/main/resources/solr/instance/templates/aps/task/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>4.9</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load an Jars
        identified and use them to resolve any "plugins" specified in

--- a/alfresco-search/src/main/resources/solr/instance/templates/aps/taskDefinition/conf/solrconfig.xml
+++ b/alfresco-search/src/main/resources/solr/instance/templates/aps/taskDefinition/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>4.9</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load an Jars
        identified and use them to resolve any "plugins" specified in

--- a/alfresco-search/src/main/resources/solr/instance/templates/noRerank/conf/solrconfig.xml
+++ b/alfresco-search/src/main/resources/solr/instance/templates/noRerank/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>4.9</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load an Jars
        identified and use them to resolve any "plugins" specified in

--- a/alfresco-search/src/main/resources/solr/instance/templates/rerank/conf/solrconfig.xml
+++ b/alfresco-search/src/main/resources/solr/instance/templates/rerank/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>4.9</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load an Jars
        identified and use them to resolve any "plugins" specified in

--- a/alfresco-search/src/main/resources/solr/instance/templates/rerankWithQueryLog/qlog/conf/solrconfig.xml
+++ b/alfresco-search/src/main/resources/solr/instance/templates/rerankWithQueryLog/qlog/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>4.9</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load an Jars
        identified and use them to resolve any "plugins" specified in

--- a/alfresco-search/src/main/resources/solr/instance/templates/rerankWithQueryLog/rerank/conf/solrconfig.xml
+++ b/alfresco-search/src/main/resources/solr/instance/templates/rerankWithQueryLog/rerank/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>4.9</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load an Jars
        identified and use them to resolve any "plugins" specified in

--- a/alfresco-search/src/test/java/org/alfresco/solr/query/Solr4QueryParserTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/query/Solr4QueryParserTest.java
@@ -51,7 +51,7 @@ public class Solr4QueryParserTest
     public void setUp() throws Exception
     {
         SolrQueryRequest req = Mockito.mock(SolrQueryRequest.class);
-        parser = new Solr4QueryParser(req, Version.LUCENE_5_5_0, "TEXT", null, FTSQueryParser.RerankPhase.SINGLE_PASS);
+        parser = new Solr4QueryParser(req, Version.LATEST, "TEXT", null, FTSQueryParser.RerankPhase.SINGLE_PASS);
         parser.setSearchParameters(searchParameters);
     }
 

--- a/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig-afts.xml
+++ b/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig-afts.xml
@@ -49,7 +49,7 @@
 
     <schemaFactory class="ClassicIndexSchemaFactory"/>
 
-    <luceneMatchVersion>${tests.luceneMatchVersion:LUCENE_CURRENT}</luceneMatchVersion>
+    <luceneMatchVersion>LATEST</luceneMatchVersion>
 
     <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 

--- a/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig-basic.xml
+++ b/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig-basic.xml
@@ -20,7 +20,7 @@
 <!-- a basic solrconfig that tests can use when they want simple minimal solrconfig/schema
      DO NOT ADD THINGS TO THIS CONFIG! -->
 <config>
-  <luceneMatchVersion>${tests.luceneMatchVersion:LUCENE_CURRENT}</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
   <dataDir>${solr.data.dir:}</dataDir>
   <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>

--- a/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig-rerank.xml
+++ b/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig-rerank.xml
@@ -47,7 +47,7 @@
         <double name="maxWriteMBPerSecRead">4000000</double>
     </directoryFactory>
 
-    <luceneMatchVersion>${tests.luceneMatchVersion:LUCENE_CURRENT}</luceneMatchVersion>
+    <luceneMatchVersion>LATEST</luceneMatchVersion>
 
     <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 

--- a/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig.xml
+++ b/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig.xml
@@ -49,7 +49,7 @@
 
     <schemaFactory class="ClassicIndexSchemaFactory"/>
 
-    <luceneMatchVersion>${tests.luceneMatchVersion:LUCENE_CURRENT}</luceneMatchVersion>
+    <luceneMatchVersion>LATEST</luceneMatchVersion>
 
     <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 


### PR DESCRIPTION
The PR contains: 

- the mnemonic code LATEST in all Solr configuration files
- the same constant value wherever the Lucene Version class is used for referring to a specific version. 