### PR TITLE
Fix/search 1309

### DIFF
--- a/alfresco-search/pom.xml
+++ b/alfresco-search/pom.xml
@@ -179,7 +179,6 @@
                                 <resource>
                                     <directory>src/main/resources/solr/instance/templates/rerank/conf</directory>
                                     <excludes>
-                                        <exclude>schema.xml</exclude>
                                         <exclude>solrconfig.xml</exclude>
                                     </excludes>
                                 </resource>

--- a/alfresco-search/src/test/java/org/alfresco/solr/CoresCreateUpdateDistributedTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/CoresCreateUpdateDistributedTest.java
@@ -66,7 +66,6 @@ public class CoresCreateUpdateDistributedTest extends AbstractAlfrescoDistribute
     private void destroyData() throws Throwable
     {
         dismissSolrServers();
-        System.clearProperty("solr.solr.home");
     }
     
     @Test
@@ -99,11 +98,6 @@ public class CoresCreateUpdateDistributedTest extends AbstractAlfrescoDistribute
         AlfrescoCoreAdminHandler coreAdminHandler = (AlfrescoCoreAdminHandler) coreContainer.getMultiCoreHandler();
         assertNotNull(coreAdminHandler);
         String coreName = "alfSharedCore";
-
-        //AlfrescoSolrDataModel.getResourceDirectory() looks for solrhome in a system property or jndi.
-        //In production there's always a solr.home but not in this test, so this is the workaround.
-        //Set it here and clean up with a @AfterClass method.
-        System.setProperty("solr.solr.home", coreContainer.getSolrHome());
 
         //First, we have no cores so we can update the shared properties, including disallowed
         updateShared(coreAdminHandler,"property.solr.host", "myhost", "property.my.property", "chocolate",

--- a/alfresco-search/src/test/java/org/alfresco/solr/SolrTestInitializer.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/SolrTestInitializer.java
@@ -134,6 +134,7 @@ public abstract class SolrTestInitializer extends SolrTestCaseJ4
         distribSetUp(serverName);
         RandomSupplier.RandVal.uniqueValues = new HashSet(); // reset random values
         createServers(serverName, coreNames, numShards,solrcoreProperties);
+        System.setProperty("solr.solr.home", testDir.toPath().resolve(serverName).toString());
     }
 
     public static void initSingleSolrServer(String testClassName, Properties solrcoreProperties) throws Throwable {
@@ -160,6 +161,7 @@ public abstract class SolrTestInitializer extends SolrTestCaseJ4
         SolrClient standaloneClient = createNewSolrClient(url);
         assertNotNull(standaloneClient);
         solrCollectionNameToStandaloneClient.put("alfresco", standaloneClient);
+        System.setProperty("solr.solr.home", testDir.toPath().resolve(testClassName).toString());
     }
 
     public static void dismissSolrServers()
@@ -196,7 +198,6 @@ public abstract class SolrTestInitializer extends SolrTestCaseJ4
         System.setProperty("solr.test.sys.prop2", "proptwo");
         System.setProperty("solr.directoryFactory", "org.apache.solr.core.MockDirectoryFactory");
         System.setProperty("solr.log.dir", testDir.toPath().resolve(serverName).toString());
-        System.setProperty("solr.solr.home", testDir.toPath().resolve(serverName).toString());
     }
 
     public static void distribTearDown() throws Exception

--- a/alfresco-search/src/test/java/org/alfresco/solr/SolrTestInitializer.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/SolrTestInitializer.java
@@ -161,7 +161,6 @@ public abstract class SolrTestInitializer extends SolrTestCaseJ4
         SolrClient standaloneClient = createNewSolrClient(url);
         assertNotNull(standaloneClient);
         solrCollectionNameToStandaloneClient.put("alfresco", standaloneClient);
-        System.setProperty("solr.solr.home", testDir.toPath().resolve(testClassName).toString());
     }
 
     public static void dismissSolrServers()

--- a/alfresco-search/src/test/java/org/alfresco/solr/SolrTestInitializer.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/SolrTestInitializer.java
@@ -196,12 +196,14 @@ public abstract class SolrTestInitializer extends SolrTestCaseJ4
         System.setProperty("solr.test.sys.prop2", "proptwo");
         System.setProperty("solr.directoryFactory", "org.apache.solr.core.MockDirectoryFactory");
         System.setProperty("solr.log.dir", testDir.toPath().resolve(serverName).toString());
+        System.setProperty("solr.solr.home", testDir.toPath().resolve(serverName).toString());
     }
 
     public static void distribTearDown() throws Exception
     {
         System.clearProperty("solr.directoryFactory");
         System.clearProperty("solr.log.dir");
+        System.clearProperty("solr.solr.home");
 
         SOLRAPIQueueClient.nodeMetaDataMap.clear();
         SOLRAPIQueueClient.transactionQueue.clear();


### PR DESCRIPTION
This Pull Request ensure the solr instances spinned up in the tests have the solr home set to fetch additional configurations such as shared.properties.