### PR TITLE
[ SEARCH-1433 ] Lazy initialisation removed + code refactoring

### DIFF
--- a/alfresco-search/src/test/java/org/alfresco/solr/SolrDataModelTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/SolrDataModelTest.java
@@ -51,7 +51,7 @@ public class SolrDataModelTest
         String id = AlfrescoSolrDataModel.getNodeDocumentId(tenant, aclId, dbId);
         TenantAclIdDbId ids = AlfrescoSolrDataModel.decodeNodeDocumentId(id);
         assertEquals(tenant,ids.tenant);
-        assertEquals(aclId, ids.alcId);
+        assertEquals(aclId, ids.aclId);
         assertEquals(dbId, ids.dbId);
     }
     


### PR DESCRIPTION
The PR contains the following: 

- removal of AlfrescoSolrDataModel singleton lazy initialisation. As consequence of that the class no longer uses the ReentrantLock, the singleton is initialized when the class is loaded. 
- removal of unused members (methods, variables)
- additional javadocs
- formatting
- minor refactoring for improving the readability (e.g. string concatenation, java 8 streams)