### PR TITLE
[ SEARCH-1433 ] Lazy initialisation removed + code refactoring

### DIFF
--- a/alfresco-search/src/main/java/org/alfresco/solr/AlfrescoSolrDataModel.java
+++ b/alfresco-search/src/main/java/org/alfresco/solr/AlfrescoSolrDataModel.java
@@ -26,6 +26,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -34,7 +35,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.model.ContentModel;
@@ -92,13 +93,9 @@ import org.apache.chemistry.opencmis.commons.enums.BaseTypeId;
 import org.apache.chemistry.opencmis.commons.enums.CapabilityJoin;
 import org.apache.chemistry.opencmis.commons.enums.CmisVersion;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.LegacyNumericUtils;
-import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.Version;
 import org.apache.solr.core.CoreDescriptorDecorator;
 import org.apache.solr.core.SolrResourceLoader;
@@ -115,10 +112,14 @@ import org.springframework.context.support.FileSystemXmlApplicationContext;
  */
 public class AlfrescoSolrDataModel implements QueryConstants
 {
+    public static class TenantAclIdDbId
+    {
+        public String tenant;
+        public Long aclId;
+        public Long dbId;
+    }
 
-    public static final String SHARED_PROPERTIES = "shared.properties";
-
-    public static enum FieldUse
+    public enum FieldUse
     {
         FTS,          // Term/Phrase/Range/Fuzzy/Prefix/Proximity/Wild
         ID,           // Exact/ExactRange - Comparison, In, Upper, Lower
@@ -127,58 +128,55 @@ public class AlfrescoSolrDataModel implements QueryConstants
         STATS,        // Stats
         SORT,         // Locale
         SUGGESTION,
-        COMPLETION, 
-        HIGHLIGHT  
+        COMPLETION,
+        HIGHLIGHT
     }
-    
-    public static enum ContentFieldType
+
+    public enum ContentFieldType
     {
         DOCID,
         SIZE,
-        LOCALE, 
+        LOCALE,
         MIMETYPE,
         ENCODING,
         TRANSFORMATION_STATUS,
         TRANSFORMATION_TIME,
         TRANSFORMATION_EXCEPTION
     }
-    
-    public static final String CONTENT_S_LOCALE_PREFIX = "content@s__locale@";
-    public static final String CONTENT_M_LOCALE_PREFIX = "content@m__locale@";
-    
+
+    static final String CONTENT_S_LOCALE_PREFIX = "content@s__locale@";
+    static final String SHARED_PROPERTIES = "shared.properties";
+
     protected final static Logger log = LoggerFactory.getLogger(AlfrescoSolrDataModel.class);
 
     private static final String CHANGE_SET = "CHANGE_SET";
 
     private static final String  TX = "TX";
-    
-    public static final String DEFAULT_TENANT = "_DEFAULT_";
-    
-    private static ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
 
-    private static AlfrescoSolrDataModel model;
+    public static final String DEFAULT_TENANT = "_DEFAULT_";
+
+    private final static AlfrescoSolrDataModel INSTANCE = new AlfrescoSolrDataModel();
 
     private TenantService tenantService;
 
     private NamespaceDAO namespaceDAO;
 
     private DictionaryDAOImpl dictionaryDAO;
-    
-    private  Map<String,DictionaryComponent> dictionaryServices;
 
-    private  Map<DictionaryKey,CMISAbstractDictionaryService> cmisDictionaryServices;
-    
-    private HashMap<String, Set<String>> modelErrors = new HashMap<String, Set<String>>();
-    
-    private HashSet<QName> suggestableProperties = new HashSet<QName>();
-    
-    private HashSet<QName> crossLocaleSearchDataTypes = new HashSet<QName>();
-    
-    private HashSet<QName> crossLocaleSearchProperties = new HashSet<QName>();
-    
-    private HashSet<QName> identifierProperties = new HashSet<QName>();
+    private Map<String,DictionaryComponent> dictionaryServices;
+
+    private Map<DictionaryKey,CMISAbstractDictionaryService> cmisDictionaryServices;
+
+    private Map<String, Set<String>> modelErrors = new HashMap<>();
+
+    private Set<QName> suggestableProperties = new HashSet<>();
+
+    private Set<QName> crossLocaleSearchDataTypes = new HashSet<>();
+
+    private Set<QName> crossLocaleSearchProperties = new HashSet<>();
+
+    private Set<QName> identifierProperties = new HashSet<>();
     private ThreadPoolExecutor threadPool;
-
 
     public void close() {
         threadPool.shutdown();
@@ -190,7 +188,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
 
         dictionaryDAO = new DictionaryDAOImpl();
         dictionaryDAO.setTenantService(tenantService);
-        
+
         try
         {
             CompiledModelsCache compiledModelsCache = new CompiledModelsCache();
@@ -205,7 +203,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
             dictionaryDAO.setResourceClassLoader(getResourceClassLoader());
             dictionaryDAO.init();
         }
-        catch (Exception e) 
+        catch (Exception e)
         {
             throw new AlfrescoRuntimeException("Failed to create dictionaryDAO ", e);
         }
@@ -218,7 +216,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
         dictionaryComponent.setMessageLookup(new StaticMessageLookup());
 
         cmisDictionaryServices = AlfrescoClientDataModelServicesFactory.constructDictionaries(qnameFilter, namespaceDAO, dictionaryComponent, dictionaryDAO);
-        
+
         Properties props = getCommonConfig();
         for (Object key : props.keySet())
         {
@@ -243,27 +241,24 @@ public class AlfrescoSolrDataModel implements QueryConstants
                 QName qName = QName.createQName(props.getProperty(stringKey));
                 identifierProperties.add(qName);
             }
-            
         }
-        
+
         if(props.isEmpty())
         {
-        	suggestableProperties.add(ContentModel.PROP_NAME);
-        	suggestableProperties.add(ContentModel.PROP_TITLE);
-        	suggestableProperties.add(ContentModel.PROP_DESCRIPTION);
-        	suggestableProperties.add(ContentModel.PROP_CONTENT);
-        	
-        	crossLocaleSearchDataTypes.add(DataTypeDefinition.TEXT);
-        	crossLocaleSearchDataTypes.add(DataTypeDefinition.CONTENT);
-        	crossLocaleSearchDataTypes.add(DataTypeDefinition.MLTEXT);
-        	
-        	identifierProperties.add(ContentModel.PROP_CREATOR);
-        	identifierProperties.add(ContentModel.PROP_MODIFIER);
-        	identifierProperties.add(ContentModel.PROP_USERNAME);
-        	identifierProperties.add(ContentModel.PROP_AUTHORITY_NAME);
-        	
+            suggestableProperties.add(ContentModel.PROP_NAME);
+            suggestableProperties.add(ContentModel.PROP_TITLE);
+            suggestableProperties.add(ContentModel.PROP_DESCRIPTION);
+            suggestableProperties.add(ContentModel.PROP_CONTENT);
+
+            crossLocaleSearchDataTypes.add(DataTypeDefinition.TEXT);
+            crossLocaleSearchDataTypes.add(DataTypeDefinition.CONTENT);
+            crossLocaleSearchDataTypes.add(DataTypeDefinition.MLTEXT);
+
+            identifierProperties.add(ContentModel.PROP_CREATOR);
+            identifierProperties.add(ContentModel.PROP_MODIFIER);
+            identifierProperties.add(ContentModel.PROP_USERNAME);
+            identifierProperties.add(ContentModel.PROP_AUTHORITY_NAME);
         }
-        
     }
 
     public static String getTenantId(String tenant)
@@ -277,83 +272,83 @@ public class AlfrescoSolrDataModel implements QueryConstants
             return tenant.replaceAll("!", "_-._");
         }
     }
-    
+
     /**
-     * 
-     * @param tenant
-     * @param aclId
-     * @return <TENANT>:<ACLID>:A-<ACLID>
+     * Returns the ACL Document identifier in the following format &lt;TENANT>!&lt;ACLID>!ACL
+     *
+     * @param tenant the tenant code.
+     * @param aclId the acl identifer
+     * @return the ACL Document identifier (&lt;TENANT>!&lt;ACLID>!ACL)
      */
-    public static String getAclDocumentId(String tenant, Long aclId)
+    static String getAclDocumentId(String tenant, Long aclId)
     {
-        StringBuilder builder = new StringBuilder();
-        builder.append(getTenantId(tenant));
-        builder.append("!");
-        builder.append(NumericEncoder.encode(aclId));
-        builder.append("!ACL");
-        return builder.toString();
+        return getTenantId(tenant) + "!" + NumericEncoder.encode(aclId) + "!ACL";
     }
-    
+
     /**
-     * 
-     * @param aclChangeSetId
-     * @return <TENANT>:CHANGE_SET:<aclChangeSetId <- max in doc if compressed>
+     * Returns the ACL ChangeSet Document identifier in the following format TRACKER!CHANGESET!&lt;ACL_CHANGESET_ID>
+     *
+     * @param aclChangeSetId the ACL changeset identifier.
+     * @return the ACL ChangeSet Document identifier (TRACKER!CHANGESET!&lt;ACL_CHANGESET_ID>)
      */
-    public static String getAclChangeSetDocumentId(Long aclChangeSetId)
+    static String getAclChangeSetDocumentId(Long aclChangeSetId)
     {
-        StringBuilder builder = new StringBuilder();
-        builder.append("TRACKER");
-        builder.append("!");
-        builder.append(CHANGE_SET);
-        builder.append("!");
-        builder.append(NumericEncoder.encode(aclChangeSetId));
-        return builder.toString();
+        return "TRACKER" + "!" + CHANGE_SET + "!" + NumericEncoder.encode(aclChangeSetId);
     }
-    
-    public static Long parseAclChangeSetId(String aclChangeSetDocumentId)
+
+    /**
+     * Extracts the ACL changeset identifier from the input document identifier.
+     * The "input document identifier" is the alphanumeric identifier used for Solr documents.
+     *
+     * @param documentId the document identifier.
+     * @see #getAclChangeSetDocumentId(Long)
+     * @return the numeric ACL changeset identifier.
+     */
+    static Long parseAclChangeSetId(String documentId)
     {
-        return parseIdFromDocumentId(aclChangeSetDocumentId);
+        return parseIdFromDocumentId(documentId);
     }
-    
-    public static Long parseTransactionId(String transactionDocumentId)
+
+    /**
+     * Extracts the transaction identifier from the input document identifier.
+     * The "input document identifier" is the alphanumeric identifier used for Solr documents.
+     *
+     * @param documentId the document identifier.
+     * @return the numeric ACL changeset identifier.
+     */
+    static Long parseTransactionId(String documentId)
     {
-        return parseIdFromDocumentId(transactionDocumentId);
+        return parseIdFromDocumentId(documentId);
     }
-    
+
     private static Long parseIdFromDocumentId(String documentId)
     {
         String[] split = documentId.split("!");
         if (split.length > 0)
             return NumericEncoder.decodeLong(split[split.length - 1]);
-        else 
+        else
             return null;
     }
-    
+
     /**
-     * Returns the Solr 4 id
-     * @param tenant
-     * @param aclId
-     * @param dbid
-     * @return <TENANT>!<ACLID>!<DBID>
+     * Returns the Solr document identifier in the following format &lt;TENANT>!&lt;ACLID>!&lt;DBID>
+     *
+     * @param tenant the tenant code.
+     * @param aclId the ACL identifier.
+     * @param dbid the DB identifier.
+     * @return the Solr document identifier in the following format &lt;TENANT>!&lt;ACLID>!&lt;DBID>
      */
     public static String getNodeDocumentId(String tenant, Long aclId, Long dbid)
     {
-        StringBuilder builder = new StringBuilder();
-        builder.append(getTenantId(tenant));
-        builder.append("!");
-        builder.append(NumericEncoder.encode(aclId));
-        builder.append("!");
-        builder.append(NumericEncoder.encode(dbid));
-        return builder.toString();
+        return getTenantId(tenant) + "!" + NumericEncoder.encode(aclId) + "!" + NumericEncoder.encode(dbid);
     }
-    
-    public static class TenantAclIdDbId
-    {
-        public String tenant;
-        public Long alcId;
-        public Long dbId;
-    }
-    
+
+    /**
+     * Destructures a document identifier in the three compounding parts (tenant, aclid and dbid).
+     *
+     * @param id the document identifier.
+     * @return a {@link TenantAclIdDbId} instance containing the destructured identifier.
+     */
     public static TenantAclIdDbId decodeNodeDocumentId(String id)
     {
         TenantAclIdDbId ids = new TenantAclIdDbId();
@@ -361,43 +356,28 @@ public class AlfrescoSolrDataModel implements QueryConstants
         if (split.length > 0)
             ids.tenant = split[0];
         if (split.length > 1)
-            ids.alcId = NumericEncoder.decodeLong(split[1]);
+            ids.aclId = NumericEncoder.decodeLong(split[1]);
         if (split.length > 2)
             ids.dbId = NumericEncoder.decodeLong(split[2]);
         return ids;
     }
-    
+
     /**
-     * 
-     * @param txId
-     * @return <TENANT>:CHANGE_SET:<txId <- max in doc if compressed>
+     * Returns the Transaction Document identifier in the following format TRACKER!TX!&lt;TX_ID>
+     *
+     * @param txId the transaction identifier.
+     * @return the Transaction Document identifier in the following format TRACKER!TX!&lt;TX_ID>
      */
-    public static String getTransactionDocumentId(Long txId)
+    static String getTransactionDocumentId(Long txId)
     {
-        StringBuilder builder = new StringBuilder();
         // TODO - check and encode for ":"
-        builder.append("TRACKER");
-        builder.append("!");
-        builder.append(TX);
-        builder.append("!");
-        builder.append(NumericEncoder.encode(txId));
-        return builder.toString();
+        return "TRACKER" +
+                "!" +
+                TX +
+                "!" +
+                NumericEncoder.encode(txId);
     }
-    
-    public static Term getLongTerm(String field, long longValue)
-    {
-        BytesRefBuilder bytesBuilder = new BytesRefBuilder();
-        LegacyNumericUtils.longToPrefixCoded(longValue, 0, bytesBuilder);
-        return new Term(field, bytesBuilder.get());
-    }
-    
-    public static Term getLongTerm(String field, String stringValue)
-    {
-        long longValue = Long.parseLong(stringValue);
-        return getLongTerm(field, longValue); 
-    }
-    
-    
+
     public String getAlfrescoPropertyFromSchemaField(String schemaField)
     {
         int index = schemaField.lastIndexOf("@{");
@@ -405,21 +385,21 @@ public class AlfrescoSolrDataModel implements QueryConstants
         {
             return schemaField;
         }
-        
+
         String alfrescoQueryField = schemaField.substring(index+1);
         QName qName = QName.createQName(alfrescoQueryField);
         alfrescoQueryField = qName.toPrefixString(namespaceDAO);
-        
+
         PropertyDefinition propertyDefinition = getPropertyDefinition(qName);
         if((propertyDefinition == null))
-        { 
+        {
             return alfrescoQueryField;
         }
         if(!propertyDefinition.isIndexed() && !propertyDefinition.isStoredInIndex())
         {
             return alfrescoQueryField;
         }
-        
+
         DataTypeDefinition dataTypeDefinition = propertyDefinition.getDataType();
         if(dataTypeDefinition.getName().equals(DataTypeDefinition.CONTENT))
         {
@@ -465,46 +445,17 @@ public class AlfrescoSolrDataModel implements QueryConstants
             return alfrescoQueryField;
         }
     }
-    
- 
+
     public static AlfrescoSolrDataModel getInstance()
     {
-        readWriteLock.readLock().lock();
-        try
-        {
-            if (model != null)
-            {
-                return model;
-            }
-        }
-        finally
-        {
-            readWriteLock.readLock().unlock();
-        }
-
-        // not found
-
-        readWriteLock.writeLock().lock();
-        try
-        {
-            if (model == null)
-            {
-                model = new AlfrescoSolrDataModel();
-            }
-            return model;
-        }
-        finally
-        {
-            readWriteLock.writeLock().unlock();
-        }
-
+        return INSTANCE;
     }
-    
+
     public NamespaceDAO getNamespaceDAO()
     {
         return namespaceDAO;
     }
-    
+
     /**
      * TODO: Fix to load type filter/exclusions from somewhere sensible
      * @return QNameFilter
@@ -524,7 +475,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
             log.info("No type filter context found at " + filterContext.getAbsolutePath() + ", no type filtering");
             return qnameFilter;
         }
-        
+
         try
         {
             ctx = new FileSystemXmlApplicationContext(new String[] { "file:" + filterContext.getAbsolutePath() }, false);
@@ -550,8 +501,8 @@ public class AlfrescoSolrDataModel implements QueryConstants
 
         return qnameFilter;
     }
-    
-    public static Properties getCommonConfig()
+
+    static Properties getCommonConfig()
     {
         File resourceDirectory = getResourceDirectory();
         // If we ever need to filter out models in the future, then we must put a filter somewhere.
@@ -564,23 +515,23 @@ public class AlfrescoSolrDataModel implements QueryConstants
             log.info("No shared properties found at  " + propertiesFile.getAbsolutePath());
             return props;
         }
-        
+
         try(InputStream is = new FileInputStream(propertiesFile))
         {
-        	props.load(is);
-        } 
-        catch (IOException e) 
+            props.load(is);
+        }
+        catch (IOException e)
         {
-        	log.info("Failed to read shared properties fat  " + propertiesFile.getAbsolutePath());
-		}
-        
+            log.info("Failed to read shared properties fat  " + propertiesFile.getAbsolutePath());
+        }
+
         return props;
     }
-    
+
     /**
      * @return ClassLoader
      */
-    public ClassLoader getResourceClassLoader()
+    private ClassLoader getResourceClassLoader()
     {
         File f = getResourceDirectory();
         if (f.canRead() && f.isDirectory())
@@ -604,12 +555,12 @@ public class AlfrescoSolrDataModel implements QueryConstants
             return this.getClass().getClassLoader();
         }
     }
-    
-    public static File getResourceDirectory()
+
+    static File getResourceDirectory()
     {
         return new File(SolrResourceLoader.locateSolrHome().toFile(), "conf");
-    }  
-    
+    }
+
     /**
      * Gets a DictionaryService, if an Alternative dictionary is specified it tries to get that.
      * It will attempt to get the DEFAULT dictionary service if null is specified or it can't find
@@ -620,32 +571,32 @@ public class AlfrescoSolrDataModel implements QueryConstants
     public DictionaryComponent getDictionaryService(String alternativeDictionary)
     {
         DictionaryComponent dictionaryComponent = null;
-        
+
         if (alternativeDictionary != null && !alternativeDictionary.trim().isEmpty())
         {
             dictionaryComponent = dictionaryServices.get(alternativeDictionary);
         }
-        
+
         if (dictionaryComponent == null)
         {
             dictionaryComponent = dictionaryServices.get(CMISStrictDictionaryService.DEFAULT);
         }
         return dictionaryComponent;
     }
-    
-    public IndexedField getIndexedFieldForContentPropertyMetadata(QName propertyQName, ContentFieldType type)
+
+    IndexedField getIndexedFieldForContentPropertyMetadata(QName propertyQName, ContentFieldType type)
     {
         IndexedField indexedField = new IndexedField();
         PropertyDefinition propertyDefinition = getPropertyDefinition(propertyQName);
         if((propertyDefinition == null))
-        { 
+        {
             return indexedField;
         }
         if(!propertyDefinition.isIndexed() && !propertyDefinition.isStoredInIndex())
         {
             return indexedField;
         }
-        
+
         DataTypeDefinition dataTypeDefinition = propertyDefinition.getDataType();
         if(dataTypeDefinition.getName().equals(DataTypeDefinition.CONTENT))
         {
@@ -658,54 +609,54 @@ public class AlfrescoSolrDataModel implements QueryConstants
             builder.append('_');
             switch (type)
             {
-            case DOCID:
-                builder.append("docid");
-                break;
-            case ENCODING:
-                builder.append("encoding");
-                break;
-            case LOCALE:
-                builder.append("locale");
-                break;
-            case MIMETYPE:
-                builder.append("mimetype");
-                break;
-            case SIZE:
-                builder.append("size");
-                break;
-            case TRANSFORMATION_EXCEPTION:
-                builder.append("tr_ex");
-                break;
-            case TRANSFORMATION_STATUS:
-                builder.append("tr_status");
-                break;
-            case TRANSFORMATION_TIME:
-                builder.append("tr_time");
-                break;
-            default:
-                break;
+                case DOCID:
+                    builder.append("docid");
+                    break;
+                case ENCODING:
+                    builder.append("encoding");
+                    break;
+                case LOCALE:
+                    builder.append("locale");
+                    break;
+                case MIMETYPE:
+                    builder.append("mimetype");
+                    break;
+                case SIZE:
+                    builder.append("size");
+                    break;
+                case TRANSFORMATION_EXCEPTION:
+                    builder.append("tr_ex");
+                    break;
+                case TRANSFORMATION_STATUS:
+                    builder.append("tr_status");
+                    break;
+                case TRANSFORMATION_TIME:
+                    builder.append("tr_time");
+                    break;
+                default:
+                    break;
             }
             builder.append('@');
             builder.append(propertyQName);
             indexedField.addField(builder.toString(), false, false);
-            
+
         }
-        return indexedField;      
-        
+        return indexedField;
+
     }
-    
-    
+
+
     public IndexedField getQueryableFields(QName propertyQName,  ContentFieldType type, FieldUse fieldUse)
     {
         if(type != null)
         {
             return getIndexedFieldForContentPropertyMetadata(propertyQName, type);
         }
-        
+
         IndexedField indexedField = new IndexedField();
         PropertyDefinition propertyDefinition = getPropertyDefinition(propertyQName);
         if((propertyDefinition == null))
-        { 
+        {
             indexedField.addField("_dummy_", false, false);
             return indexedField;
         }
@@ -714,43 +665,43 @@ public class AlfrescoSolrDataModel implements QueryConstants
             indexedField.addField("_dummy_", false, false);
             return indexedField;
         }
-        
+
         if(isTextField(propertyDefinition))
         {
-           switch(fieldUse)
-           {
-           case COMPLETION:
-               addCompletionFields(propertyDefinition, indexedField);
-               break;
-           case FACET:
-               addFacetSearchFields(propertyDefinition, indexedField);
-               break;
-           case FTS:
-               addFullTextSearchFields(propertyDefinition, indexedField);
-               break;
-           case ID:
-               addIdentifierSearchFields(propertyDefinition, indexedField);
-               break;
-           case MULTI_FACET:
-               addMultiSearchFields(propertyDefinition, indexedField);
-               break;
-           case SORT:
-               addSortSearchFields(propertyDefinition, indexedField);
-               break;
-           case STATS:
-               addStatsSearchFields(propertyDefinition, indexedField);
-               break;
-           case SUGGESTION:
-               if(isSuggestable(propertyQName))
-               {
-                   indexedField.addField("suggest", false, false);
-               }
-               addCompletionFields(propertyDefinition, indexedField);
-               break;
-           case HIGHLIGHT:
-               addHighlightSearchFields(propertyDefinition, indexedField);
-               break;
-           }
+            switch(fieldUse)
+            {
+                case COMPLETION:
+                    addCompletionFields(propertyDefinition, indexedField);
+                    break;
+                case FACET:
+                    addFacetSearchFields(propertyDefinition, indexedField);
+                    break;
+                case FTS:
+                    addFullTextSearchFields(propertyDefinition, indexedField);
+                    break;
+                case ID:
+                    addIdentifierSearchFields(propertyDefinition, indexedField);
+                    break;
+                case MULTI_FACET:
+                    addMultiSearchFields(propertyDefinition, indexedField);
+                    break;
+                case SORT:
+                    addSortSearchFields(propertyDefinition, indexedField);
+                    break;
+                case STATS:
+                    addStatsSearchFields(propertyDefinition, indexedField);
+                    break;
+                case SUGGESTION:
+                    if(isSuggestable(propertyQName))
+                    {
+                        indexedField.addField("suggest", false, false);
+                    }
+                    addCompletionFields(propertyDefinition, indexedField);
+                    break;
+                case HIGHLIGHT:
+                    addHighlightSearchFields(propertyDefinition, indexedField);
+                    break;
+            }
         }
         else
         {
@@ -758,46 +709,44 @@ public class AlfrescoSolrDataModel implements QueryConstants
         }
         return indexedField;
     }
-    
+
     /*
-     * Adds best completion fields in order of preference 
+     * Adds best completion fields in order of preference
      */
-   
-    private void addCompletionFields( PropertyDefinition propertyDefinition , IndexedField indexedField)
+    private void addCompletionFields(PropertyDefinition propertyDefinition, IndexedField indexedField)
     {
         if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH))
         {
-        	if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-        	{
+            if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
+            {
                 indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-        	}
-        	else
-        	{
-        		 indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
-        	}
+            }
+            else
+            {
+                indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
+            }
         }
         else if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.TRUE))
         {
-        	if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-        	{
+            if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
+            {
                 indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-        	}
-        	else
-        	{
-        		 indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
-        	}
+            }
+            else
+            {
+                indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
+            }
         }
         else if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE))
         {
             indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
         }
-                
     }
-    
+
     /*
-     * Adds best fts fields in order of preference 
+     * Adds best fts fields in order of preference
      */
-   
+
     private void addFullTextSearchFields( PropertyDefinition propertyDefinition , IndexedField indexedField)
     {
         if (((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.TRUE)
@@ -806,48 +755,47 @@ public class AlfrescoSolrDataModel implements QueryConstants
         {
             indexedField.addField(getFieldForText(true, true, false, propertyDefinition), true, false);
             if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-        	{
+            {
                 indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-        	}
+            }
         }
         else
         {
             indexedField.addField(getFieldForText(true, false, false, propertyDefinition), true, false);
             indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
-        }        
+        }
     }
-    
+
     private void addHighlightSearchFields( PropertyDefinition propertyDefinition , IndexedField indexedField)
     {
         if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.TRUE)
                 || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH))
         {
-        	if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-        	{
+            if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
+            {
                 indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
                 indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
-        	}
-        	else
-        	{
-        		 indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
-        	}
+            }
+            else
+            {
+                indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
+            }
         }
         else
         {
             indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
-        }        
+        }
     }
-    
+
     /*
-     * Adds best identifier fields in order of preference 
+     * Adds best identifier fields in order of preference
      */
-   
-    private void addIdentifierSearchFields( PropertyDefinition propertyDefinition , IndexedField indexedField)
+    private void addIdentifierSearchFields(PropertyDefinition propertyDefinition, IndexedField indexedField)
     {
         if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
                 || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH))
         {
-            
+
             indexedField.addField(getFieldForText(true, false, false, propertyDefinition), true, false);
             indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
         }
@@ -855,17 +803,16 @@ public class AlfrescoSolrDataModel implements QueryConstants
         {
             indexedField.addField(getFieldForText(true, true, false, propertyDefinition), true, false);
             if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-        	{
+            {
                 indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-        	}
-        }        
+            }
+        }
     }
-    
+
     /*
-     * Adds best identifier fields in order of preference 
+     * Adds best identifier fields in order of preference
      */
-   
-    private void addFacetSearchFields( PropertyDefinition propertyDefinition , IndexedField indexedField)
+    private void addFacetSearchFields(PropertyDefinition propertyDefinition, IndexedField indexedField)
     {
         if(propertyDefinition.getDataType().getName().equals(DataTypeDefinition.TEXT))
         {
@@ -877,62 +824,62 @@ public class AlfrescoSolrDataModel implements QueryConstants
                 }
             }
         }
-        
-        
+
+
         if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
                 || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH)
                 || isIdentifierTextProperty(propertyDefinition.getName()))
         {
-            
+
             indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
         }
         else
         {
-        	if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-        	{
+            if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
+            {
                 indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-        	}
-        	else
-        	{
-        		 indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
-        	}
-        }        
+            }
+            else
+            {
+                indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
+            }
+        }
     }
-    
+
     private void addMultiSearchFields( PropertyDefinition propertyDefinition , IndexedField indexedField)
     {
-    	if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
-    			|| (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH)
-    			|| isIdentifierTextProperty(propertyDefinition.getName()))
-    	{
+        if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
+                || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH)
+                || isIdentifierTextProperty(propertyDefinition.getName()))
+        {
 
-    		indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
-    	}
-    	else
-    	{
-    		if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-    		{
-    			indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-    		}
-    		else
-    		{
-    			indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
-    		}
-    	}       
+            indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
+        }
+        else
+        {
+            if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
+            {
+                indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
+            }
+            else
+            {
+                indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
+            }
+        }
     }
-    
+
     private void addStatsSearchFields( PropertyDefinition propertyDefinition , IndexedField indexedField)
     {
         addFacetSearchFields(propertyDefinition, indexedField);
     }
-    
+
     private void addSortSearchFields( PropertyDefinition propertyDefinition , IndexedField indexedField)
     {
         // Can only order on single valued fields
         DataTypeDefinition dataTypeDefinition = propertyDefinition.getDataType();
         if(dataTypeDefinition.getName().equals(DataTypeDefinition.TEXT))
-        {	
-            if(propertyDefinition.isMultiValued() == false)
+        {
+            if(!propertyDefinition.isMultiValued())
             {
                 if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
                         || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH))
@@ -941,25 +888,25 @@ public class AlfrescoSolrDataModel implements QueryConstants
                 }
                 else if (isIdentifierTextProperty(propertyDefinition.getName()))
                 {
-                    indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);   
+                    indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
                 }
                 else
                 {
-                	if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-            		{
-            			indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-            		}
-            		else
-            		{
-            			indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
-            		}
+                    if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
+                    {
+                        indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
+                    }
+                    else
+                    {
+                        indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
+                    }
                 }
             }
         }
 
         if(dataTypeDefinition.getName().equals(DataTypeDefinition.MLTEXT))
         {
-            if(propertyDefinition.isMultiValued() == false)
+            if(!propertyDefinition.isMultiValued())
             {
                 if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
                         || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH))
@@ -968,34 +915,33 @@ public class AlfrescoSolrDataModel implements QueryConstants
                 }
                 else
                 {
-                	if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-            		{
-            			indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-            		}
-            		else
-            		{
-            			indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
-            		}
+                    if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
+                    {
+                        indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
+                    }
+                    else
+                    {
+                        indexedField.addField(getFieldForText(true, true, false, propertyDefinition), false, false);
+                    }
                 }
             }
         }
     }
-    
-    
+
     /**
      * Get all the field names into which we must copy the source data
-     * 
+     *
      * @param propertyQName QName
      * @return IndexedField
      */
     public IndexedField getIndexedFieldNamesForProperty(QName propertyQName)
     {
         // TODO: Cache and throw on model refresh
-        
+
         IndexedField indexedField = new IndexedField();
         PropertyDefinition propertyDefinition = getPropertyDefinition(propertyQName);
         if((propertyDefinition == null))
-        { 
+        {
             return indexedField;
         }
         if(!propertyDefinition.isIndexed() && !propertyDefinition.isStoredInIndex())
@@ -1005,24 +951,24 @@ public class AlfrescoSolrDataModel implements QueryConstants
 
         DataTypeDefinition dataTypeDefinition = propertyDefinition.getDataType();
         if(isTextField(propertyDefinition))
-        { 
+        {
             if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.TRUE)
                     || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH))
             {
                 indexedField.addField(getFieldForText(true, true, false, propertyDefinition), true, false);
                 if(crossLocaleSearchDataTypes.contains(propertyDefinition.getDataType().getName()) || crossLocaleSearchProperties.contains(propertyDefinition.getName()))
-        		{
-        			indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
-        		}
+                {
+                    indexedField.addField(getFieldForText(false, true, false, propertyDefinition), false, false);
+                }
             }
-            
+
             if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
                     || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH
                     || isIdentifierTextProperty(propertyDefinition.getName())))
             {
                 indexedField.addField(getFieldForText(true, false, false, propertyDefinition), true, false);
                 indexedField.addField(getFieldForText(false, false, false, propertyDefinition), false, false);
-                
+
             }
 
             if(dataTypeDefinition.getName().equals(DataTypeDefinition.TEXT))
@@ -1030,7 +976,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
                 if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
                         || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH))
                 {
-                    if(propertyDefinition.isMultiValued() == false)
+                    if(!propertyDefinition.isMultiValued())
                     {
                         indexedField.addField(getFieldForText(false, false, true, propertyDefinition), false, true);
                     }
@@ -1043,22 +989,22 @@ public class AlfrescoSolrDataModel implements QueryConstants
                     }
                 }
             }
-            
+
             if(dataTypeDefinition.getName().equals(DataTypeDefinition.MLTEXT))
             {
                 if ((propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
                         || (propertyDefinition.getIndexTokenisationMode() == IndexTokenisationMode.BOTH))
                 {
-                    if(propertyDefinition.isMultiValued() == false)
+                    if(!propertyDefinition.isMultiValued())
                     {
                         indexedField.addField(getFieldForText(true, false, true, propertyDefinition), true, true);
                     }
-                }   
+                }
             }
-            
+
             if(isSuggestable(propertyQName))
             {
-                indexedField.addField("suggest_@"+propertyDefinition.getName().toString(), false, false);
+                indexedField.addField("suggest_@" + propertyDefinition.getName().toString(), false, false);
             }
         }
         else
@@ -1067,16 +1013,11 @@ public class AlfrescoSolrDataModel implements QueryConstants
         }
 
         return indexedField;
-
     }
 
-    /**
-     * @param propertyQName QName
-     * @return boolean
-     */
     private boolean isIdentifierTextProperty(QName propertyQName)
     {
-    	return identifierProperties.contains(propertyQName);
+        return identifierProperties.contains(propertyQName);
     }
 
     private boolean isTextField(PropertyDefinition propertyDefinition)
@@ -1090,17 +1031,9 @@ public class AlfrescoSolrDataModel implements QueryConstants
         {
             return true;
         }
-        else if(propertyDataTypeQName.equals(DataTypeDefinition.TEXT))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        else return propertyDataTypeQName.equals(DataTypeDefinition.TEXT);
     }
-    
-         
+
     private boolean isSuggestable(QName propertyQName)
     {
         if(propertyQName == null)
@@ -1109,21 +1042,14 @@ public class AlfrescoSolrDataModel implements QueryConstants
         }
         return suggestableProperties.contains(propertyQName);
     }
-    
+
     private boolean hasDocValues(PropertyDefinition propertyDefinition)
     {
 
         if(isTextField(propertyDefinition))
         {
-            // We only call this if text is untokenised and localised 
-            if(propertyDefinition.getFacetable() == Facetable.FALSE)
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
+            // We only call this if text is untokenised and localised
+            return propertyDefinition.getFacetable() != Facetable.FALSE;
         }
         else
         {
@@ -1147,13 +1073,8 @@ public class AlfrescoSolrDataModel implements QueryConstants
                 }
             }
         }
-
     }
-    
-    /**
-     * @param dataType DataTypeDefinition
-     * @return boolean
-     */
+
     private boolean isPrimitive(DataTypeDefinition dataType)
     {
         if(dataType.getName().equals(DataTypeDefinition.INT))
@@ -1188,17 +1109,10 @@ public class AlfrescoSolrDataModel implements QueryConstants
         {
             return true;
         }
-        else if(dataType.getName().equals(DataTypeDefinition.NODE_REF))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        else return dataType.getName().equals(DataTypeDefinition.NODE_REF);
     }
 
-    public String getFieldForNonText(PropertyDefinition propertyDefinition)
+    private String getFieldForNonText(PropertyDefinition propertyDefinition)
     {
         StringBuilder builder = new StringBuilder();
         QName qName = propertyDefinition.getDataType().getName();
@@ -1210,7 +1124,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
         builder.append(propertyDefinition.getName().toString());
         return builder.toString();
     }
-    
+
     private String getFieldForText(boolean localised, boolean tokenised, boolean sort, PropertyDefinition propertyDefinition)
     {
         StringBuilder builder = new StringBuilder();
@@ -1252,51 +1166,16 @@ public class AlfrescoSolrDataModel implements QueryConstants
         builder.append(propertyDefinition.getName().toString());
         return builder.toString();
     }
-    
-    
- 
-    
 
-    /**
-     * @param propertyQName QName
-     * @return PropertyDefinition
-     */
-    public PropertyDefinition getPropertyDefinition(QName propertyQName)
+    private PropertyDefinition getPropertyDefinition(QName propertyQName)
     {
-        PropertyDefinition propertyDef = getDictionaryService(CMISStrictDictionaryService.DEFAULT).getProperty(propertyQName);
-        return propertyDef;
+        return getDictionaryService(CMISStrictDictionaryService.DEFAULT).getProperty(propertyQName);
     }
-    
-    
-    
-    
-//    public PropertyDefinition getPropertyDefinition(QName propertyQName)
-//    {
-//        PropertyDefinition propertyDef = getDictionaryService(CMISStrictDictionaryService.DEFAULT).getProperty(propertyQName);
-//        if ((propertyDef != null) && (propertyDef.getName().equals(ContentModel.PROP_AUTHOR)))
-//        {
-//            return new PropertyDefinitionWrapper(propertyDef);
-//        }
-//        else if ((propertyDef != null) && (propertyDef.getName().equals(ContentModel.PROP_CREATOR)))
-//        {
-//            return new PropertyDefinitionWrapper(propertyDef);
-//        }
-//        else if ((propertyDef != null) && (propertyDef.getName().equals(ContentModel.PROP_MODIFIER)))
-//        {
-//            return new PropertyDefinitionWrapper(propertyDef);
-//        }
-//        return propertyDef;
-//    }
-    
-    
-    /**
-     * @param model M2Model
-     * @return boolean
-     */
-    public boolean putModel(M2Model model)
+
+    boolean putModel(M2Model model)
     {
         Set<String> errors = validateModel(model);
-        if(errors.size() == 0)
+        if(errors.isEmpty())
         {
             modelErrors.remove(model.getName());
             dictionaryDAO.putModelIgnoringConstraints(model);
@@ -1311,49 +1190,41 @@ public class AlfrescoSolrDataModel implements QueryConstants
             }
             return false;
         }
-       
     }
 
-    public boolean removeModel(QName modelQName)
+    public void removeModel(QName modelQName)
     {
-    	modelErrors.remove(modelQName);
-    	dictionaryDAO.removeModel(modelQName); 
-    	return true;
+        // FIXME: this has no effect. The method should be changed (SEARCH-1482)
+        modelErrors.remove(modelQName);
+
+        dictionaryDAO.removeModel(modelQName);
     }
-    
+
     private Set<String> validateModel(M2Model model)
     {
-        HashSet<String> errors = new HashSet<String>();
-        try 
-        { 
-            dictionaryDAO.getCompiledModel(QName.createQName(model.getName(), namespaceDAO)); 
-        } 
-        catch (DictionaryException e) 
+        try
+        {
+            dictionaryDAO.getCompiledModel(QName.createQName(model.getName(), namespaceDAO));
+        }
+        catch (DictionaryException | NamespaceException exception)
         {
             // No model to diff
-            return errors;
+            return Collections.emptySet();
         }
-        catch(NamespaceException e)
-        {
-            // namespace unknown - no model 
-            return errors;
-        }
-        
-        
+
+        // namespace unknown - no model
         List<M2ModelDiff> modelDiffs = dictionaryDAO.diffModelIgnoringConstraints(model);
-        
-        for (M2ModelDiff modelDiff : modelDiffs)
-        {
-            if (modelDiff.getDiffType().equals(M2ModelDiff.DIFF_UPDATED))
-            {
-                errors.add("Model not updated: "+model.getName()  + "   Failed to validate model update - found non-incrementally updated " + modelDiff.getElementType() + " '" + modelDiff.getElementName() + "'");
-            }
-        }
-        return errors;
+        return modelDiffs.stream()
+                .filter(diff -> diff.getDiffType().equals(M2ModelDiff.DIFF_UPDATED))
+                .map(diff ->
+                        String.format("Model not updated: %s Failed to validate model update - found non-incrementally updated %s '%s'",
+                                model.getName(),
+                                diff.getElementType(),
+                                diff.getElementName()))
+                .collect(Collectors.toSet());
     }
-  
-    
-    public M2Model getM2Model(QName modelQName)
+
+    M2Model getM2Model(QName modelQName)
     {
         return dictionaryDAO.getCompiledModel(modelQName).getM2Model();
     }
@@ -1365,9 +1236,9 @@ public class AlfrescoSolrDataModel implements QueryConstants
             cds.afterDictionaryInit();
         }
     }
-    
+
     public org.alfresco.repo.search.impl.querymodel.Query parseCMISQueryToAlfrescoAbstractQuery(CMISQueryMode mode, SearchParameters searchParameters,
-            SolrQueryRequest req, String alternativeDictionary, CmisVersion cmisVersion) 
+                                                                                                SolrQueryRequest req, String alternativeDictionary, CmisVersion cmisVersion)
     {
         // convert search parameters to cmis query options
         // TODO: how to handle store ref
@@ -1382,16 +1253,16 @@ public class AlfrescoSolrDataModel implements QueryConstants
         options.setQueryParameterDefinitions(searchParameters.getQueryParameterDefinitions());
         for(String name : searchParameters.getQueryTemplates().keySet())
         {
-        	String template = searchParameters.getQueryTemplates().get(name);
-        	options.addQueryTemplate(name, template);
+            String template = searchParameters.getQueryTemplates().get(name);
+            options.addQueryTemplate(name, template);
         }
 
         // parse cmis syntax
         CapabilityJoin joinSupport = (mode == CMISQueryMode.CMS_STRICT) ? CapabilityJoin.NONE : CapabilityJoin.INNERANDOUTER;
         CmisFunctionEvaluationContext functionContext = getCMISFunctionEvaluationContext(mode, cmisVersion, alternativeDictionary);
-        
+
         CMISDictionaryService cmisDictionary = getCMISDictionary(alternativeDictionary, cmisVersion);
-        
+
         CMISQueryParser parser = new CMISQueryParser(options, cmisDictionary, joinSupport);
         org.alfresco.repo.search.impl.querymodel.Query queryModelQuery = parser.parse(new LuceneQueryModelFactory<Query, Sort, SyntaxError>(), functionContext);
 
@@ -1405,7 +1276,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
         }
         return queryModelQuery;
     }
-    
+
     public CmisFunctionEvaluationContext getCMISFunctionEvaluationContext(CMISQueryMode mode, CmisVersion cmisVersion, String alternativeDictionary)
     {
         BaseTypeId[] validScopes = (mode == CMISQueryMode.CMS_STRICT) ? CmisFunctionEvaluationContext.STRICT_SCOPES : CmisFunctionEvaluationContext.ALFRESCO_SCOPES;
@@ -1414,24 +1285,25 @@ public class AlfrescoSolrDataModel implements QueryConstants
         functionContext.setValidScopes(validScopes);
         return functionContext;
     }
-    
+
     /**
      * Gets the CMISDictionaryService, if an Alternative dictionary is specified it tries to get that.
      * It will attempt to get the DEFAULT dictionary service if null is specified or it can't find
      * a dictionary with the name of "alternativeDictionary"
+     *
      * @param alternativeDictionary - can be null;
      * @return CMISDictionaryService
      */
-    public CMISDictionaryService getCMISDictionary(String alternativeDictionary, CmisVersion cmisVersion)
+    private CMISDictionaryService getCMISDictionary(String alternativeDictionary, CmisVersion cmisVersion)
     {
         CMISDictionaryService cmisDictionary = null;
-        
+
         if (alternativeDictionary != null && !alternativeDictionary.trim().isEmpty())
         {
             DictionaryKey key = new DictionaryKey(cmisVersion, alternativeDictionary);
             cmisDictionary = cmisDictionaryServices.get(key);
         }
-        
+
         if (cmisDictionary == null)
         {
             DictionaryKey key = new DictionaryKey(cmisVersion, CMISStrictDictionaryService.DEFAULT);
@@ -1441,348 +1313,31 @@ public class AlfrescoSolrDataModel implements QueryConstants
     }
 
     /**
+     * Returns the Alfresco models associated with the current dictionary.
      *
-     * @return List<AlfrescoModel>
+     * @return the Alfresco models associated with the current dictionary.
      */
-    public List<AlfrescoModel> getAlfrescoModels()
+    List<AlfrescoModel> getAlfrescoModels()
     {
-
-        ArrayList<AlfrescoModel> answer = new ArrayList<AlfrescoModel>();
-        for (QName modelName : dictionaryDAO.getModels())
-        {
-            M2Model m2Model = dictionaryDAO.getCompiledModel(modelName).getM2Model();
-            answer.add(new AlfrescoModel(m2Model, getDictionaryService(CMISStrictDictionaryService.DEFAULT).getModel(modelName).getChecksum(ModelDefinition.XMLBindingType.DEFAULT)));
-        }
-        return answer;
-
+        return dictionaryDAO.getModels().stream()
+                .map(qname -> {
+                    M2Model m2Model = dictionaryDAO.getCompiledModel(qname).getM2Model();
+                    return new AlfrescoModel(
+                            m2Model,
+                            getDictionaryService(
+                                    CMISStrictDictionaryService.DEFAULT).getModel(qname).getChecksum(ModelDefinition.XMLBindingType.DEFAULT));})
+                .collect(Collectors.toList());
     }
 
-    /**
-     * @return Map<String, Set<String>>
-     */
-    public Map<String, Set<String>> getModelErrors()
+    Map<String, Set<String>> getModelErrors()
     {
-       return modelErrors;
+        return modelErrors;
     }
-    
-    
-//    public static final class TextSortFieldComparator extends FieldComparator<String>
-//    {
-//
-//        private final String[] values;
-//
-//        private String[] currentReaderValues;
-//
-//        private final String field;
-//
-//        final Collator collator;
-//
-//        private String bottom;
-//        
-//        private String top;
-//
-//        TextSortFieldComparator(int numHits, String field, Locale locale)
-//        {
-//            values = new String[numHits];
-//            this.field = field;
-//            collator = Collator.getInstance(locale);
-//        }
-//
-//        /*
-//         * (non-Javadoc)
-//         * @see org.apache.lucene.search.FieldComparator#compare(int, int)
-//         */
-//        @Override
-//        public int compare(int slot1, int slot2)
-//        {
-//            final String val1 = values[slot1];
-//            final String val2 = values[slot2];
-//            if (val1 == null)
-//            {
-//                if (val2 == null)
-//                {
-//                    return 0;
-//                }
-//                return -1;
-//            }
-//            else if (val2 == null)
-//            {
-//                return 1;
-//            }
-//            return collator.compare(val1, val2);
-//        }
-//
-//        /*
-//         * (non-Javadoc)
-//         * @see org.apache.lucene.search.FieldComparator#compareBottom(int)
-//         */
-//        @Override
-//        public int compareBottom(int doc)
-//        {
-//            final String val2 = stripLocale(currentReaderValues[doc]);
-//            if (bottom == null)
-//            {
-//                if (val2 == null)
-//                {
-//                    return 0;
-//                }
-//                return -1;
-//            }
-//            else if (val2 == null)
-//            {
-//                return 1;
-//            }
-//            return collator.compare(bottom, val2);
-//        }
-//
-//        /*
-//         * (non-Javadoc)
-//         * @see org.apache.lucene.search.FieldComparator#copy(int, int)
-//         */
-//        @Override
-//        public void copy(int slot, int doc)
-//        {
-//            values[slot] = stripLocale(currentReaderValues[doc]);
-//        }
-//
-////        public void setNextReader(IndexReader reader, int docBase) throws IOException
-////        {
-////            currentReaderValues = FieldCache.DEFAULT.getStrings(reader, field);
-////        }
-//
-//        /*
-//         * (non-Javadoc)
-//         * @see org.apache.lucene.search.FieldComparator#setBottom(int)
-//         */
-//        @Override
-//        public void setBottom(final int bottom)
-//        {
-//            this.bottom = values[bottom];
-//        }
-//
-////        public Comparable value(int slot)
-////        {
-////            return values[slot];
-////        }
-//
-//        private String stripLocale(String withLocale)
-//        {
-//            if (withLocale == null)
-//            {
-//                return withLocale;
-//            }
-//            else if (withLocale.startsWith("\u0000"))
-//            {
-//                return withLocale.substring(withLocale.indexOf('\u0000', 1) + 1);
-//            }
-//            else
-//            {
-//                return withLocale;
-//            }
-//        }
-//
-//        /* (non-Javadoc)
-//         * @see org.apache.lucene.search.FieldComparator#setTopValue(java.lang.Object)
-//         */
-//        @Override
-//        public void setTopValue(String value)
-//        {
-//           this.top = value;
-//            
-//        }
-//
-//        /* (non-Javadoc)
-//         * @see org.apache.lucene.search.FieldComparator#compareTop(int)
-//         */
-//        @Override
-//        public int compareTop(int doc) throws IOException
-//        {
-//            final String val2 = stripLocale(currentReaderValues[doc]);
-//            if (top == null)
-//            {
-//                if (val2 == null)
-//                {
-//                    return 0;
-//                }
-//                return -1;
-//            }
-//            else if (val2 == null)
-//            {
-//                return 1;
-//            }
-//            return collator.compare(top, val2);
-//        }
-//
-//        /* (non-Javadoc)
-//         * @see org.apache.lucene.search.FieldComparator#setNextReader(org.apache.lucene.index.AtomicReaderContext)
-//         */
-//        @Override
-//        public FieldComparator setNextReader(AtomicReaderContext context) throws IOException
-//        {
-//            currentReaderValues = FieldCache.DEFAULT.getTerms(reader, field, setDocsWithField)getStrings(context, field);
-//        }
-//    }
 
-//    public static class MLTextSortFieldComparatorSource extends FieldComparatorSource
-//    {
-//
-//        /*
-//         * (non-Javadoc)
-//         * @see org.apache.lucene.search.FieldComparatorSource#newComparator(java.lang.String, int, int, boolean)
-//         */
-//        @Override
-//        public FieldComparator newComparator(String fieldname, int numHits, int sortPos, boolean reversed) throws IOException
-//        {
-//            return new MLTextSortFieldComparator(numHits, fieldname, I18NUtil.getLocale());
-//        }
-//
-//    }
-
-//    public static final class MLTextSortFieldComparator extends FieldComparator
-//    {
-//
-//        private final String[] values;
-//
-//        private String[] currentReaderValues;
-//
-//        private final String field;
-//
-//        final Collator collator;
-//
-//        private String bottom;
-//
-//        Locale collatorLocale;
-//
-//        MLTextSortFieldComparator(int numHits, String field, Locale collatorLocale)
-//        {
-//            values = new String[numHits];
-//            this.field = field;
-//            this.collatorLocale = collatorLocale;
-//            collator = Collator.getInstance(collatorLocale);
-//        }
-//
-//        public int compare(int slot1, int slot2)
-//        {
-//            final String val1 = values[slot1];
-//            final String val2 = values[slot2];
-//            if (val1 == null)
-//            {
-//                if (val2 == null)
-//                {
-//                    return 0;
-//                }
-//                return -1;
-//            }
-//            else if (val2 == null)
-//            {
-//                return 1;
-//            }
-//            return collator.compare(val1, val2);
-//        }
-//
-//        public int compareBottom(int doc)
-//        {
-//            final String val2 = findBestValue(currentReaderValues[doc]);
-//            if (bottom == null)
-//            {
-//                if (val2 == null)
-//                {
-//                    return 0;
-//                }
-//                return -1;
-//            }
-//            else if (val2 == null)
-//            {
-//                return 1;
-//            }
-//            return collator.compare(bottom, val2);
-//        }
-//
-//        public void copy(int slot, int doc)
-//        {
-//            values[slot] = findBestValue(currentReaderValues[doc]);
-//        }
-//
-//        public void setNextReader(IndexReader reader, int docBase) throws IOException
-//        {
-//            currentReaderValues = FieldCache.DEFAULT.getStrings(reader, field);
-//        }
-//
-//        public void setBottom(final int bottom)
-//        {
-//            this.bottom = values[bottom];
-//        }
-//
-//        public Comparable value(int slot)
-//        {
-//            return values[slot];
-//        }
-//
-//        private String findBestValue(String withLocale)
-//        {
-//            // split strin into MLText object
-//            if (withLocale == null)
-//            {
-//                return withLocale;
-//            }
-//            else if (withLocale.startsWith("\u0000"))
-//            {
-//                MLText mlText = new MLText();
-//                String[] parts = withLocale.split("\u0000");
-//                for (int i = 0; (i + 2) <= parts.length; i += 3)
-//                {
-//                    Locale locale = null;
-//                    String[] localeParts = parts[i + 1].split("_");
-//                    if (localeParts.length == 1)
-//                    {
-//                        locale = new Locale(localeParts[0]);
-//                    }
-//                    else if (localeParts.length == 2)
-//                    {
-//                        locale = new Locale(localeParts[0], localeParts[1]);
-//                    }
-//                    else if (localeParts.length == 3)
-//                    {
-//                        locale = new Locale(localeParts[0], localeParts[1], localeParts[2]);
-//                    }
-//                    if (locale != null)
-//                    {
-//                        if (i + 2 == parts.length)
-//                        {
-//                            mlText.addValue(locale, "");
-//                        }
-//                        else
-//                        {
-//                            mlText.addValue(locale, parts[i + 2]);
-//                        }
-//                    }
-//                }
-//                return mlText.getClosestValue(collatorLocale);
-//            }
-//            else
-//            {
-//                return withLocale;
-//            }
-//        }
-//    }
-
-   
     public static class IndexedField
     {
-
         private List<FieldInstance> fields = new LinkedList<>();
 
-        public IndexedField()
-        {
-            super();
-        }
-        
-        public IndexedField(String prefix, boolean localised, boolean sort)
-        {
-            this();
-            addField(prefix, localised, sort);
-        }
-        
         public List<FieldInstance> getFields()
         {
             return fields;
@@ -1792,20 +1347,14 @@ public class AlfrescoSolrDataModel implements QueryConstants
         {
             fields.add(new FieldInstance(prefix, localised, sort));
         }
-        
     }
-    
+
     public static class FieldInstance
     {
-        String field;
-        boolean localised;
-        boolean sort;
-        
-        /**
-         * @param field String
-         * @param localised boolean
-         * @param sort boolean
-         */
+        final String field;
+        final boolean localised;
+        final boolean sort;
+
         public FieldInstance(String field, boolean localised, boolean sort)
         {
             this.field = field;
@@ -1817,7 +1366,7 @@ public class AlfrescoSolrDataModel implements QueryConstants
         {
             return field;
         }
-        
+
         public boolean isLocalised()
         {
             return localised;
@@ -1826,25 +1375,14 @@ public class AlfrescoSolrDataModel implements QueryConstants
         public boolean isSort()
         {
             return sort;
-        }   
+        }
     }
 
-    /**
-     *
-     * @param mode CMISQueryMode
-     * @param searchParametersAndFilter Pair<SearchParameters, Boolean>
-     * @param req SolrQueryRequest
-     * @param queryModelQuery Query
-     * @param cmisVersion CmisVersion
-     * @param alternativeDictionary String
-     * @return Query
-     * @throws ParseException
-     */
-     public Query getCMISQuery(CMISQueryMode mode, Pair<SearchParameters, Boolean> searchParametersAndFilter, SolrQueryRequest req, org.alfresco.repo.search.impl.querymodel.Query queryModelQuery, CmisVersion cmisVersion, String alternativeDictionary) throws ParseException
+    public Query getCMISQuery(CMISQueryMode mode, Pair<SearchParameters, Boolean> searchParametersAndFilter, SolrQueryRequest req, org.alfresco.repo.search.impl.querymodel.Query queryModelQuery, CmisVersion cmisVersion, String alternativeDictionary) throws ParseException
     {
         SearchParameters searchParameters = searchParametersAndFilter.getFirst();
         Boolean isFilter = searchParametersAndFilter.getSecond();
-        
+
         CmisFunctionEvaluationContext functionContext = getCMISFunctionEvaluationContext(mode, cmisVersion, alternativeDictionary);
 
         Set<String> selectorGroup = queryModelQuery.getSource().getSelectorGroups(functionContext).get(0);
@@ -1854,224 +1392,213 @@ public class AlfrescoSolrDataModel implements QueryConstants
         LuceneQueryBuilder<Query, Sort, ParseException> builder = (LuceneQueryBuilder<Query, Sort, ParseException>) queryModelQuery;
         org.apache.lucene.search.Query luceneQuery = builder.buildQuery(selectorGroup, luceneContext, functionContext);
 
-        ContextAwareQuery contextAwareQuery = new ContextAwareQuery(luceneQuery, Boolean.TRUE.equals(isFilter) ? null : searchParameters);
-        return contextAwareQuery;
+        return new ContextAwareQuery(luceneQuery, Boolean.TRUE.equals(isFilter) ? null : searchParameters);
     }
-     
-     public LuceneQueryBuilderContext<Query, Sort, ParseException> getLuceneQueryBuilderContext(SearchParameters searchParameters, SolrQueryRequest req, String alternativeDictionary, FTSQueryParser.RerankPhase rerankPhase)
-     {
-         Lucene4QueryBuilderContextSolrImpl luceneContext = new Lucene4QueryBuilderContextSolrImpl(getDictionaryService(alternativeDictionary), namespaceDAO, tenantService, searchParameters,
-                 MLAnalysisMode.EXACT_LANGUAGE, req, this, rerankPhase);
-         return luceneContext;
-     }
 
-     public Solr4QueryParser getLuceneQueryParser(SearchParameters searchParameters, SolrQueryRequest req, FTSQueryParser.RerankPhase rerankPhase)
-     {
-         Analyzer analyzer =  req.getSchema().getQueryAnalyzer();
-         Solr4QueryParser parser = new Solr4QueryParser(req, Version.LUCENE_5_5_0, searchParameters.getDefaultFieldName(), analyzer, rerankPhase);
-         parser.setNamespacePrefixResolver(namespaceDAO);
-         parser.setDictionaryService(getDictionaryService(CMISStrictDictionaryService.DEFAULT));
-         parser.setTenantService(tenantService);
-         parser.setSearchParameters(searchParameters);
-         parser.setAllowLeadingWildcard(true);
-         
-         Properties props = new CoreDescriptorDecorator(req.getCore().getCoreDescriptor()).getProperties();
-         int topTermSpanRewriteLimit = Integer.parseInt(props.getProperty("alfresco.topTermSpanRewriteLimit", "1000"));
-         parser.setTopTermSpanRewriteLimit(topTermSpanRewriteLimit);
+    private LuceneQueryBuilderContext<Query, Sort, ParseException> getLuceneQueryBuilderContext(SearchParameters searchParameters, SolrQueryRequest req, String alternativeDictionary, FTSQueryParser.RerankPhase rerankPhase)
+    {
+        return new Lucene4QueryBuilderContextSolrImpl(
+                getDictionaryService(alternativeDictionary),
+                namespaceDAO,
+                tenantService,
+                searchParameters,
+                MLAnalysisMode.EXACT_LANGUAGE,
+                req,
+                this,
+                rerankPhase);
+    }
 
-         return parser;
-     }
+    public Solr4QueryParser getLuceneQueryParser(SearchParameters searchParameters, SolrQueryRequest req, FTSQueryParser.RerankPhase rerankPhase)
+    {
+        Analyzer analyzer =  req.getSchema().getQueryAnalyzer();
+        Solr4QueryParser parser = new Solr4QueryParser(req, Version.LUCENE_5_5_0, searchParameters.getDefaultFieldName(), analyzer, rerankPhase);
+        parser.setNamespacePrefixResolver(namespaceDAO);
+        parser.setDictionaryService(getDictionaryService(CMISStrictDictionaryService.DEFAULT));
+        parser.setTenantService(tenantService);
+        parser.setSearchParameters(searchParameters);
+        parser.setAllowLeadingWildcard(true);
+
+        Properties props = new CoreDescriptorDecorator(req.getCore().getCoreDescriptor()).getProperties();
+        int topTermSpanRewriteLimit = Integer.parseInt(props.getProperty("alfresco.topTermSpanRewriteLimit", "1000"));
+        parser.setTopTermSpanRewriteLimit(topTermSpanRewriteLimit);
+
+        return parser;
+    }
+
+    public Query getFTSQuery(Pair<SearchParameters, Boolean> searchParametersAndFilter, SolrQueryRequest req, FTSQueryParser.RerankPhase rerankPhase) throws ParseException
+    {
+
+        SearchParameters searchParameters = searchParametersAndFilter.getFirst();
+        Boolean isFilter = searchParametersAndFilter.getSecond();
+
+        QueryModelFactory factory = new LuceneQueryModelFactory<Query, Sort, SyntaxError>();
+        AlfrescoFunctionEvaluationContext functionContext = new AlfrescoSolr4FunctionEvaluationContext(namespaceDAO, getDictionaryService(CMISStrictDictionaryService.DEFAULT), NamespaceService.CONTENT_MODEL_1_0_URI, req.getSchema());
+
+        FTSParser.Mode mode;
+
+        if (searchParameters.getDefaultFTSOperator() == org.alfresco.service.cmr.search.SearchParameters.Operator.AND)
+        {
+            mode = FTSParser.Mode.DEFAULT_CONJUNCTION;
+        }
+        else
+        {
+            mode = FTSParser.Mode.DEFAULT_DISJUNCTION;
+        }
+
+        Constraint constraint = FTSQueryParser.buildFTS(searchParameters.getQuery(), factory, functionContext, null, null, mode,
+                searchParameters.getDefaultFTSOperator() == org.alfresco.service.cmr.search.SearchParameters.Operator.OR ? Connective.OR : Connective.AND,
+                searchParameters.getQueryTemplates(), searchParameters.getDefaultFieldName(), rerankPhase);
+        org.alfresco.repo.search.impl.querymodel.Query queryModelQuery = factory.createQuery(null, null, constraint, new ArrayList<Ordering>());
+
+        @SuppressWarnings("unchecked")
+        LuceneQueryBuilder<Query, Sort, ParseException> builder = (LuceneQueryBuilder<Query, Sort, ParseException>) queryModelQuery;
+
+        LuceneQueryBuilderContext<Query, Sort, ParseException> luceneContext = getLuceneQueryBuilderContext(searchParameters, req, CMISStrictDictionaryService.DEFAULT, rerankPhase);
+
+        Set<String> selectorGroup = null;
+        if (queryModelQuery.getSource() != null)
+        {
+            List<Set<String>> selectorGroups = queryModelQuery.getSource().getSelectorGroups(functionContext);
+
+            if (selectorGroups.size() == 0)
+            {
+                throw new UnsupportedOperationException("No selectors");
+            }
+
+            if (selectorGroups.size() > 1)
+            {
+                throw new UnsupportedOperationException("Advanced join is not supported");
+            }
+
+            selectorGroup = selectorGroups.get(0);
+        }
+        Query luceneQuery = builder.buildQuery(selectorGroup, luceneContext, functionContext);
+        // query needs some search parameters fro correct caching ....
+
+        return new ContextAwareQuery(luceneQuery, Boolean.TRUE.equals(isFilter) ? null : searchParameters);
+    }
+
+    private PropertyDefinition getPropertyDefinition(String identifier)
+    {
+        return QueryParserUtils.matchPropertyDefinition(NamespaceService.CONTENT_MODEL_1_0_URI,
+                getNamespaceDAO(),
+                getDictionaryService(CMISStrictDictionaryService.DEFAULT),
+                identifier);
+    }
+
+    public String  mapProperty(String  potentialProperty,  FieldUse fieldUse, SolrQueryRequest req)
+    {
+        return mapProperty(potentialProperty, fieldUse, req, 0);
+    }
+
+    public String  mapProperty(String  potentialProperty,  FieldUse fieldUse, SolrQueryRequest req, int position)
+    {
+        if(potentialProperty.equals("asc") || potentialProperty.equals("desc") || potentialProperty.equals("_docid_"))
+        {
+            return potentialProperty;
+        }
+
+        if(potentialProperty.equalsIgnoreCase("score") || potentialProperty.equalsIgnoreCase("SEARCH_SCORE"))
+        {
+            return "score";
+        }
+
+        if(req.getSchema().getFieldOrNull(potentialProperty) != null)
+        {
+            return mapNonPropertyFields(potentialProperty);
+        }
+
+        AlfrescoFunctionEvaluationContext functionContext =
+                new AlfrescoSolr4FunctionEvaluationContext(
+                        getNamespaceDAO(),
+                        getDictionaryService(CMISStrictDictionaryService.DEFAULT),
+                        NamespaceService.CONTENT_MODEL_1_0_URI,
+                        req.getSchema());
+
+        Pair<String, String> fieldNameAndEnding = QueryParserUtils.extractFieldNameAndEnding(potentialProperty);
+        String luceneField =  functionContext.getLuceneFieldName(fieldNameAndEnding.getFirst());
+
+        PropertyDefinition propertyDef = getPropertyDefinition(fieldNameAndEnding.getFirst());
+        //Retry scan using luceneField.
+        if(propertyDef == null)
+        {
+            if(luceneField.contains("@"))
+            {
+                int index = luceneField.lastIndexOf("@");
+                propertyDef = getPropertyDefinition(luceneField.substring(index +1));
+            }
+        }
+        String solrSortField;
+        if(propertyDef != null)
+        {
+
+            IndexedField fields = AlfrescoSolrDataModel.getInstance().getQueryableFields(propertyDef.getName(), getTextField(fieldNameAndEnding.getSecond()), fieldUse);
+            if(fields.getFields().size() > 0)
+            {
+                if(fields.getFields().size() > position)
+                {
+                    solrSortField = fields.getFields().get(position).getField();
+                }
+                else
+                {
+                    solrSortField = fields.getFields().get(0).getField();
+                }
+            }
+            else
+            {
+                solrSortField = mapNonPropertyFields(luceneField);
+            }
+        }
+        else
+        {
+            solrSortField = mapNonPropertyFields(luceneField);
+        }
+        return solrSortField;
+    }
+
+    private String mapNonPropertyFields(String queryField)
+    {
+        switch(queryField)
+        {
+            case "ID":
+                return "LID";
+            case "EXACTTYPE":
+                return "TYPE";
+            default:
+                return queryField;
+
+        }
+    }
 
     /**
-     * @param searchParametersAndFilter Pair<SearchParameters, Boolean>
-     * @param req SolrQueryRequest
-     * @return Query
-     * @throws ParseException
+     * @param ending String
+     * @return ContentFieldType
      */
-     public Query getFTSQuery(Pair<SearchParameters, Boolean> searchParametersAndFilter, SolrQueryRequest req, FTSQueryParser.RerankPhase rerankPhase) throws ParseException
-     {
+    private ContentFieldType getTextField(String ending)
+    {
+        switch(ending)
+        {
+            case FIELD_MIMETYPE_SUFFIX:
+                return ContentFieldType.MIMETYPE;
+            case FIELD_SIZE_SUFFIX:
+                return ContentFieldType.SIZE;
+            case FIELD_LOCALE_SUFFIX:
+                return ContentFieldType.LOCALE;
+            case FIELD_ENCODING_SUFFIX:
+                return ContentFieldType.ENCODING;
+            case FIELD_TRANSFORMATION_STATUS_SUFFIX:
+            case FIELD_TRANSFORMATION_TIME_SUFFIX:
+            case FIELD_TRANSFORMATION_EXCEPTION_SUFFIX:
+            default:
+                return null;
+        }
+    }
 
-         SearchParameters searchParameters = searchParametersAndFilter.getFirst();
-         Boolean isFilter = searchParametersAndFilter.getSecond();
-
-         QueryModelFactory factory = new LuceneQueryModelFactory<Query, Sort, SyntaxError>();
-         AlfrescoFunctionEvaluationContext functionContext = new AlfrescoSolr4FunctionEvaluationContext(namespaceDAO, getDictionaryService(CMISStrictDictionaryService.DEFAULT), NamespaceService.CONTENT_MODEL_1_0_URI, req.getSchema());
-
-         FTSParser.Mode mode;
-
-         if (searchParameters.getDefaultFTSOperator() == org.alfresco.service.cmr.search.SearchParameters.Operator.AND)
-         {
-             mode = FTSParser.Mode.DEFAULT_CONJUNCTION;
-         }
-         else
-         {
-             mode = FTSParser.Mode.DEFAULT_DISJUNCTION;
-         }
-
-         Constraint constraint = FTSQueryParser.buildFTS(searchParameters.getQuery(), factory, functionContext, null, null, mode,
-                 searchParameters.getDefaultFTSOperator() == org.alfresco.service.cmr.search.SearchParameters.Operator.OR ? Connective.OR : Connective.AND,
-                         searchParameters.getQueryTemplates(), searchParameters.getDefaultFieldName(), rerankPhase);
-         org.alfresco.repo.search.impl.querymodel.Query queryModelQuery = factory.createQuery(null, null, constraint, new ArrayList<Ordering>());
-
-         @SuppressWarnings("unchecked")
-         LuceneQueryBuilder<Query, Sort, ParseException> builder = (LuceneQueryBuilder<Query, Sort, ParseException>) queryModelQuery;
-
-         LuceneQueryBuilderContext<Query, Sort, ParseException> luceneContext = getLuceneQueryBuilderContext(searchParameters, req, CMISStrictDictionaryService.DEFAULT, rerankPhase);
-
-         Set<String> selectorGroup = null;
-         if (queryModelQuery.getSource() != null)
-         {
-             List<Set<String>> selectorGroups = queryModelQuery.getSource().getSelectorGroups(functionContext);
-
-             if (selectorGroups.size() == 0)
-             {
-                 throw new UnsupportedOperationException("No selectors");
-             }
-
-             if (selectorGroups.size() > 1)
-             {
-                 throw new UnsupportedOperationException("Advanced join is not supported");
-             }
-
-             selectorGroup = selectorGroups.get(0);
-         }
-         Query luceneQuery = builder.buildQuery(selectorGroup, luceneContext, functionContext);
-         // query needs some search parameters fro correct caching ....
-
-         ContextAwareQuery contextAwareQuery = new ContextAwareQuery(luceneQuery, Boolean.TRUE.equals(isFilter) ? null : searchParameters);
-         return contextAwareQuery;
-     }
-     private PropertyDefinition getPropertyDefinition(String identifier)
-     {
-         return QueryParserUtils.matchPropertyDefinition(NamespaceService.CONTENT_MODEL_1_0_URI,
-                                                         getNamespaceDAO(),
-                                                         getDictionaryService(CMISStrictDictionaryService.DEFAULT),
-                                                         identifier);
-     }
-    /**
-     *
-     * @param potentialProperty String
-     * @param fieldUse FieldUse
-     * @param req SolrQueryRequest
-     * @return String
-     */
-     public String  mapProperty(String  potentialProperty,  FieldUse fieldUse, SolrQueryRequest req)
-     {
-    	 return mapProperty(potentialProperty, fieldUse, req, 0);
-     }
-     
-     
-     public String  mapProperty(String  potentialProperty,  FieldUse fieldUse, SolrQueryRequest req, int position)
-     {
-         if(potentialProperty.equals("asc") || potentialProperty.equals("desc") || potentialProperty.equals("_docid_"))
-         {
-             return potentialProperty;
-         }
-         
-         if(potentialProperty.equalsIgnoreCase("score") || potentialProperty.equalsIgnoreCase("SEARCH_SCORE"))
-         {
-             return "score";
-         }
-         
-         if(req.getSchema().getFieldOrNull(potentialProperty) != null)
-         {
-        	 return mapNonPropertyFields(potentialProperty);
-         }
-         
-         AlfrescoFunctionEvaluationContext functionContext = new AlfrescoSolr4FunctionEvaluationContext(getNamespaceDAO(),  getDictionaryService(CMISStrictDictionaryService.DEFAULT), NamespaceService.CONTENT_MODEL_1_0_URI, req.getSchema());
-
-         Pair<String, String> fieldNameAndEnding = QueryParserUtils.extractFieldNameAndEnding(potentialProperty);
-         String luceneField =  functionContext.getLuceneFieldName(fieldNameAndEnding.getFirst());
-
-
-         PropertyDefinition propertyDef = getPropertyDefinition(fieldNameAndEnding.getFirst());
-         //Retry scan using luceneField.
-         if(propertyDef == null)
-         {
-             if(luceneField.contains("@"))
-             {
-                 int index = luceneField.lastIndexOf("@");
-                 propertyDef = getPropertyDefinition(luceneField.substring(index +1));
-             }    
-         }
-         String solrSortField = null;
-         if(propertyDef != null)
-         {
-
-             IndexedField fields = AlfrescoSolrDataModel.getInstance().getQueryableFields(propertyDef.getName(), getTextField(fieldNameAndEnding.getSecond()), fieldUse);
-             if(fields.getFields().size() > 0)
-             {
-            	 if(fields.getFields().size() > position)
-            	 {
-            		 solrSortField = fields.getFields().get(position).getField();
-            	 }
-            	 else
-            	 {
-                     solrSortField = fields.getFields().get(0).getField();
-            	 }
-             }
-             else
-             {
-                 solrSortField = mapNonPropertyFields(luceneField);
-             }
-         }
-         else
-         {
-             solrSortField = mapNonPropertyFields(luceneField);
-         }
-         return solrSortField;
-       
-     }
-     /**
-      * @param queryField String
-      * @return String
-      */
-     public String mapNonPropertyFields(String queryField)
-     {
-         switch(queryField)
-         {
-         case "ID":
-             return "LID";
-         case "EXACTTYPE":
-             return "TYPE";
-         default:
-             return queryField;
-                   
-         }
-     }
-
-     /**
-      * @param ending String
-      * @return ContentFieldType
-      */
-     public ContentFieldType getTextField(String ending)
-     {
-         switch(ending)
-         {
-         case FIELD_MIMETYPE_SUFFIX:
-             return ContentFieldType.MIMETYPE;
-         case FIELD_SIZE_SUFFIX:
-             return ContentFieldType.SIZE;
-         case FIELD_LOCALE_SUFFIX:
-             return ContentFieldType.LOCALE;
-         case FIELD_ENCODING_SUFFIX:
-             return ContentFieldType.ENCODING;
-         case FIELD_TRANSFORMATION_STATUS_SUFFIX:
-         case FIELD_TRANSFORMATION_TIME_SUFFIX:
-         case FIELD_TRANSFORMATION_EXCEPTION_SUFFIX:
-         default:
-             return null;
-                 
-         }
-         
-     }
-
-     public void setCMDefaultUri()
-     {
-         if(getNamespaceDAO().getURIs().contains(NamespaceService.CONTENT_MODEL_1_0_URI))
-         {
-             getNamespaceDAO().addPrefix("", NamespaceService.CONTENT_MODEL_1_0_URI);
-         }
-     }
-     
+    public void setCMDefaultUri()
+    {
+        if(getNamespaceDAO().getURIs().contains(NamespaceService.CONTENT_MODEL_1_0_URI))
+        {
+            getNamespaceDAO().addPrefix("", NamespaceService.CONTENT_MODEL_1_0_URI);
+        }
+    }
 }

--- a/alfresco-search/src/test/java/org/alfresco/solr/SolrDataModelTest.java
+++ b/alfresco-search/src/test/java/org/alfresco/solr/SolrDataModelTest.java
@@ -51,7 +51,7 @@ public class SolrDataModelTest
         String id = AlfrescoSolrDataModel.getNodeDocumentId(tenant, aclId, dbId);
         TenantAclIdDbId ids = AlfrescoSolrDataModel.decodeNodeDocumentId(id);
         assertEquals(tenant,ids.tenant);
-        assertEquals(aclId, ids.alcId);
+        assertEquals(aclId, ids.aclId);
         assertEquals(dbId, ids.dbId);
     }
     


### PR DESCRIPTION
The PR invalidates https://github.com/Alfresco/SearchServices/pull/109 and it contains the following:

* removal of AlfrescoSolrDataModel singleton lazy initialisation. As consequence of that the class no longer uses the ReentrantLock, the singleton is initialized when the class is loaded.
* removal of unused members (methods, variables)
* additional javadocs
* formatting
* minor refactoring for improving the readability (e.g. string concatenation, java 8 streams)