### PR TITLE
Remove SCM section from alfresco-solrclient-lib.

### DIFF
--- a/alfresco-solrclient-lib/pom.xml
+++ b/alfresco-solrclient-lib/pom.xml
@@ -10,13 +10,6 @@
         <version>1.4.0-SNAPSHOT</version>
     </parent>
 
-    <scm>
-        <connection>scm:git:git@github.com:Alfresco/alfresco-solrclient.git</connection>
-        <developerConnection>scm:git:git@github.com:Alfresco/alfresco-solrclient.git</developerConnection>
-        <url>https://github.com/Alfresco/alfresco-solrclient</url>
-        <tag>HEAD</tag>
-    </scm>
-
     <distributionManagement>
         <repository>
             <id>alfresco-internal</id>


### PR DESCRIPTION
This was left by accident when merging the projects.