### PR TITLE
Remove unused dependency.

### DIFF
--- a/alfresco-solrclient-lib/pom.xml
+++ b/alfresco-solrclient-lib/pom.xml
@@ -43,13 +43,6 @@
             <artifactId>jackson-annotations</artifactId>
             <version>2.9.8</version>
         </dependency>
-        <!-- provided dependencies -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>


### PR DESCRIPTION
The dependency javax.servlet-api is marked as provided, but when testing removal locally
there is no impact on the build.