### PR TITLE
Use 'org.mockito.junit.MockitoJUnitRunner'

### DIFF
--- a/search-services/alfresco-solrclient-lib/src/test/java/org/alfresco/solr/client/SOLRAPIClientFactoryTest.java
+++ b/search-services/alfresco-solrclient-lib/src/test/java/org/alfresco/solr/client/SOLRAPIClientFactoryTest.java
@@ -41,7 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SOLRAPIClientFactoryTest


### PR DESCRIPTION
#365 

Changed to use `org.mockito.junit.MockitoJUnitRunner`.

[org.mockito.junit - Class MockitoJUnitRunner](https://www.javadoc.io/doc/org.mockito/mockito-core/3.4.6/org/mockito/junit/MockitoJUnitRunner.html)