### PR TITLE
Prevent NullPointerException terminating foreach()

### DIFF
--- a/search-services/alfresco-search/src/main/java/org/apache/solr/core/CoreDescriptorDecorator.java
+++ b/search-services/alfresco-search/src/main/java/org/apache/solr/core/CoreDescriptorDecorator.java
@@ -92,7 +92,10 @@ public class CoreDescriptorDecorator
         try
         {
             coreProperties.forEach(prop ->
-                 properties.put(prop, ConfigUtil.locateProperty(prop,properties.getProperty(prop)))
+                 String value = ConfigUtil.locateProperty(prop, null);
+                 if (value != null) {
+                     properties.put(prop, value);
+                 }
             );
         }
         catch(Exception e)

--- a/search-services/alfresco-search/src/main/java/org/apache/solr/core/CoreDescriptorDecorator.java
+++ b/search-services/alfresco-search/src/main/java/org/apache/solr/core/CoreDescriptorDecorator.java
@@ -91,12 +91,12 @@ public class CoreDescriptorDecorator
         
         try
         {
-            coreProperties.forEach(prop ->
-                 String value = ConfigUtil.locateProperty(prop, null);
-                 if (value != null) {
-                     properties.put(prop, value);
-                 }
-            );
+            for (String prop : coreProperties) {
+                String value = ConfigUtil.locateProperty(prop, null);
+                if (value != null) {
+                    properties.put(prop, value);
+                }
+            }
         }
         catch(Exception e)
         {

--- a/search-services/alfresco-search/src/test/java/org/alfresco/solr/config/ConfigUtilTest.java
+++ b/search-services/alfresco-search/src/test/java/org/alfresco/solr/config/ConfigUtilTest.java
@@ -28,12 +28,15 @@ package org.alfresco.solr.config;
 
 import org.alfresco.solr.AlfrescoCoreAdminHandler;
 import org.alfresco.solr.SolrInformationServer;
+import org.apache.solr.core.CoreDescriptor;
+import org.apache.solr.core.CoreDescriptorDecorator;
 import org.junit.Test;
 
-import java.util.Map;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 /**
  * Tests configuring and setup of Alfresco and Solr properties

--- a/search-services/alfresco-search/src/test/java/org/alfresco/solr/config/ConfigUtilTest.java
+++ b/search-services/alfresco-search/src/test/java/org/alfresco/solr/config/ConfigUtilTest.java
@@ -75,4 +75,36 @@ public class ConfigUtilTest {
         assertEquals("SOLR_SOLR_BASEURL",ConfigUtil.convertPropertyNameToEnvironmentParam(SolrInformationServer.SOLR_BASEURL));
     }
 
+    /**
+     * See https://github.com/Alfresco/SearchServices/pull/382
+     */
+    @Test
+    public void testMissingCoreProperty()
+    {
+        HashMap<String,String> coreProps = new HashMap<String,String>();
+        Properties saved = (Properties)System.getProperties().clone();
+        System.setProperty("alfresco.secureComms", "https");
+        for (String key : CoreDescriptorDecorator.SUBSTITUTABLE_PROPERTIES_SECURE) {
+            // Intentionally omit store provider settings
+            if (!key.endsWith("store.provider")) {
+                // Set store type as system property
+                if (key.endsWith("store.type")) {
+                    System.setProperty(key, "JKS");
+                }
+                coreProps.put(key, "irrelevant");
+            }
+        }
+        Properties contProps = new Properties();
+        File tmp = new File("/tmp");
+        CoreDescriptor coreDesc = new CoreDescriptor("test", tmp.toPath(), coreProps, contProps, false);
+        CoreDescriptorDecorator decorator = new CoreDescriptorDecorator(coreDesc);
+        Properties decProps = decorator.getProperties();
+        // Verify store types are in system property
+        assertEquals("JKS", ConfigUtil.locateProperty("alfresco.encryption.ssl.keystore.type", null));
+        assertEquals("JKS", ConfigUtil.locateProperty("alfresco.encryption.ssl.truststore.type", null));
+        // Verify store types in CoreDescriptor came from system property
+        assertEquals("JKS", decProps.get("alfresco.encryption.ssl.keystore.type"));
+        assertEquals("JKS", decProps.get("alfresco.encryption.ssl.truststore.type"));
+        System.setProperties(saved);
+    }
 }


### PR DESCRIPTION
Also, there is no point getting 'prop' from 'properties' only to put it back if not null. This fixes https://github.com/Alfresco/SearchServices/issues/381