### PR TITLE
Remove unused include of solrconfig_insight.xml from solrconfig.xml

### DIFF
--- a/search-services/alfresco-search/src/main/resources/solr/instance/templates/noRerank/conf/solrconfig.xml
+++ b/search-services/alfresco-search/src/main/resources/solr/instance/templates/noRerank/conf/solrconfig.xml
@@ -1913,10 +1913,6 @@
       <int name="buckets">10</int>
   </queryParser>
 
-  <xi:include href="solrconfig_insight.xml" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <xi:fallback/>
-  </xi:include>
-
   <searchComponent name="setLocale"     class="org.alfresco.solr.component.SetLocaleComponent" />
   <searchComponent name="clearLocale"   class="org.alfresco.solr.component.ClearLocaleComponent" />
   <searchComponent name="rewriteFacetParameters"     class="org.alfresco.solr.component.RewriteFacetParametersComponent" />

--- a/search-services/alfresco-search/src/main/resources/solr/instance/templates/rerank/conf/solrconfig.xml
+++ b/search-services/alfresco-search/src/main/resources/solr/instance/templates/rerank/conf/solrconfig.xml
@@ -1956,10 +1956,6 @@
       <int name="buckets">10</int>
   </queryParser>
 
-  <xi:include href="solrconfig_insight.xml" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <xi:fallback/>
-  </xi:include>
-
   <searchComponent name="setLocale"     class="org.alfresco.solr.component.SetLocaleComponent" />
   <searchComponent name="clearLocale"   class="org.alfresco.solr.component.ClearLocaleComponent" />
   <searchComponent name="rewriteFacetParameters"     class="org.alfresco.solr.component.RewriteFacetParametersComponent" />

--- a/search-services/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig.xml
+++ b/search-services/alfresco-search/src/test/resources/test-files/collection1/conf/solrconfig.xml
@@ -504,11 +504,7 @@
     -->
 
     <queryParser name="cmis" class="org.alfresco.solr.query.CmisQParserPlugin"/>
-
-    <xi:include href="solrconfig_insight.xml" xmlns:xi="http://www.w3.org/2001/XInclude">
-        <xi:fallback/>
-    </xi:include>
-
+  
     <queryParser name="mimetype" class="org.alfresco.solr.query.MimetypeGroupingQParserPlugin" >
         <str name="mapping">conf/mime_types.csv</str>
     </queryParser>
@@ -581,4 +577,3 @@
     <transformer name="cached" class="org.alfresco.solr.transformer.AlfrescoFieldMapperTransformerFactory" />
     <transformer name="fmap" class="org.alfresco.solr.transformer.AlfrescoFieldMapperTransformerFactory"/>
 </config>
-

--- a/search-services/alfresco-search/src/test/resources/test-files/master/conf/solrconfig.xml
+++ b/search-services/alfresco-search/src/test/resources/test-files/master/conf/solrconfig.xml
@@ -516,10 +516,6 @@
 
     <queryParser name="cmis" class="org.alfresco.solr.query.CmisQParserPlugin"/>
 
-    <xi:include href="solrconfig_insight.xml" xmlns:xi="http://www.w3.org/2001/XInclude">
-        <xi:fallback/>
-    </xi:include>
-
     <queryParser name="mimetype" class="org.alfresco.solr.query.MimetypeGroupingQParserPlugin" >
         <str name="mapping">conf/mime_types.csv</str>
     </queryParser>
@@ -594,4 +590,3 @@
     <transformer name="cached" class="org.alfresco.solr.transformer.AlfrescoFieldMapperTransformerFactory" />
     <transformer name="fieldMapper" class="org.alfresco.solr.transformer.AlfrescoFieldMapperTransformerFactory" />
 </config>
-

--- a/search-services/alfresco-search/src/test/resources/test-files/slave/conf/solrconfig.xml
+++ b/search-services/alfresco-search/src/test/resources/test-files/slave/conf/solrconfig.xml
@@ -492,10 +492,6 @@
 
     <queryParser name="cmis" class="org.alfresco.solr.query.CmisQParserPlugin"/>
 
-    <xi:include href="solrconfig_insight.xml" xmlns:xi="http://www.w3.org/2001/XInclude">
-        <xi:fallback/>
-    </xi:include>
-
     <queryParser name="mimetype" class="org.alfresco.solr.query.MimetypeGroupingQParserPlugin" >
         <str name="mapping">conf/mime_types.csv</str>
     </queryParser>
@@ -568,4 +564,3 @@
     <transformer name="cached" class="org.alfresco.solr.transformer.AlfrescoFieldMapperTransformerFactory" />
     <transformer name="fmap" class="org.alfresco.solr.transformer.AlfrescoFieldMapperTransformerFactory"/>
 </config>
-


### PR DESCRIPTION
The config file `solrconfig.xml`include the file `solrconfig_insight.xml`, but the file `solrconfig_insight.xml` is not part of the installation.

To remove the `WARN` from the logs I have removed the include.

````
2022-09-28 12:43:05.083 WARN  (Thread-12) [   x:alfresco] o.a.s.c.Config XML parse warning in "solrres:/solrconfig.xml", line 1959, column 88: Include operation failed, reverting to fallbac
k. Resource error reading file as XML (href='solrconfig_insight.xml'). Reason: Can't find resource 'solrconfig_insight.xml' in classpath or '/opt/alfresco-search-services/solrhome/archive'
````

My work is based on  `docker.io/alfresco/alfresco-search-services:2.0.3`
