### PR TITLE
Content tracking with configurable txn batch size

### DIFF
--- a/search-services/alfresco-search/src/main/java/org/alfresco/solr/SolrInformationServer.java
+++ b/search-services/alfresco-search/src/main/java/org/alfresco/solr/SolrInformationServer.java
@@ -99,6 +99,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.IsoFields;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -121,12 +122,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.LongHashSet;
-import com.carrotsearch.hppc.cursors.LongCursor;
 
 import org.alfresco.httpclient.AuthenticationException;
 import org.alfresco.model.ContentModel;
@@ -466,6 +465,8 @@ public class SolrInformationServer implements InformationServer
     private final boolean dateFieldDestructuringHasBeenEnabledOnThisInstance;
 
     private final boolean enabledIndexCustomContent;
+    private final int contentIndexingTxnIdLookupBatchSize;
+    private final int contentIndexingTxnProcessingBatchSize;
 
     static class DocListCollector implements Collector, LeafCollector
     {
@@ -529,14 +530,15 @@ public class SolrInformationServer implements InformationServer
     static class TxnCollector extends DelegatingCollector
     {
         private NumericDocValues currentLongs;
-        private final LongHashSet txnSet = new LongHashSet(1000);
+        private final LongHashSet txnSet;
         private final long txnFloor;
         private final long txnCeil;
 
-        TxnCollector(long txnFloor)
+        TxnCollector(long txnFloor, int txnIdLookupMaxOffset)
         {
             this.txnFloor = txnFloor;
-            this.txnCeil = txnFloor+500;
+            this.txnCeil = txnFloor + txnIdLookupMaxOffset;
+            this.txnSet = new LongHashSet(txnIdLookupMaxOffset);
         }
 
         @Override
@@ -650,6 +652,9 @@ public class SolrInformationServer implements InformationServer
         baseUrl = baseUrl(props);
 
         enabledIndexCustomContent =  Boolean.parseBoolean(coreConfiguration.getProperty("solr.enableIndexingCustomContent", "false"));
+
+        contentIndexingTxnIdLookupBatchSize = Math.max(1, Integer.parseInt(coreConfiguration.getProperty("alfresco.content.txnIdLookupBatchSize", "500")));
+        contentIndexingTxnProcessingBatchSize = Math.max(1, Integer.parseInt(coreConfiguration.getProperty("alfresco.content.txnProcessingBatchSize", "500")));
 
         dateFieldDestructuringHasBeenEnabledOnThisInstance = Boolean.parseBoolean(coreConfiguration.getProperty("alfresco.destructureDateFields", "true"));
         LOGGER.info(
@@ -955,8 +960,8 @@ public class SolrInformationServer implements InformationServer
 
             //Find the next N transactions
             //The TxnCollector collects the transaction ids from the matching documents
-            //The txnIds are limited to a range >= the txnFloor and < an arbitrary transaction ceiling.
-            TxnCollector txnCollector = new TxnCollector(txnFloor);
+            //The txnIds are limited to a range >= the txnFloor and < a transaction ceiling with configurable offset.
+            TxnCollector txnCollector = new TxnCollector(txnFloor, contentIndexingTxnIdLookupBatchSize);
             searcher.search(documentsWithOutdatedContentQuery(), txnCollector);
             LongHashSet txnSet = txnCollector.getTxnSet();
 
@@ -969,9 +974,13 @@ public class SolrInformationServer implements InformationServer
             FieldType fieldType = searcher.getSchema().getField(FIELD_INTXID).getType();
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
 
-            for (LongCursor cursor : txnSet)
+            // sort to process oldest to newest transactions
+            long[] txnArray = txnSet.toArray();
+            Arrays.sort(txnArray);
+
+            for (int txnIdx = 0; txnIdx < txnArray.length && txnIdx < contentIndexingTxnProcessingBatchSize; txnIdx++)
             {
-                long txnID = cursor.value;
+                long txnID = txnArray[txnIdx];
                 //Build up the query for the filter of transactions we need to pull the dirty content for.
                 TermQuery txnIDQuery = new TermQuery(new Term(FIELD_INTXID, fieldType.readableToIndexed(Long.toString(txnID))));
                 builder.add(new BooleanClause(txnIDQuery, BooleanClause.Occur.SHOULD));


### PR DESCRIPTION
This pull requests adds two optional configurations to the content tracking process that allow users / customers to

- set a transaction ID lookup offset instead of relying on a hard-coded 500 offset
- set a transaction ID processing batch size for collecting documents to be content-indexed

This purpose of these configurations is to allow optimisations for (re-)indexation processes over Alfresco systems with extremely sparse transaction / content update distributions. This affects e.g. systems undergoing a lot of fine grained updates where content transactions with indexable content updates may be spread substantially. In such systems, the costly `getDocsWithUncleanContent` operation may often be invoked yielding only a single- to low double-digit number of content-containing nodes to be indexed. This may significantly prolong content indexation as the phases to perform concurrent content indexation are very short and may not even be able to use all allowed concurrent threads in the fork-join pool.

As for default values, both options use the previously hard-coded 500 txn offset, so that there is no difference in behaviour to previous versions. Users / customers with sparse transaction / content update distributions may configure substantially higher values as needed. I personally would recommend that Alfresco consider setting a default value for `alfresco.content.txnIdLookupBatchSize` that is maybe an order of magnitude larger than for `alfresco.content.txnProcessingBatchSize` - due to backwards consistency concerns I have not included that in the PR.