### PR TITLE
Remove superflous schema default for LAST_INCOMING_CONTENT_VERSION_ID

### DIFF
--- a/search-services/alfresco-search/src/main/resources/solr/instance/templates/rerank/conf/schema.xml
+++ b/search-services/alfresco-search/src/main/resources/solr/instance/templates/rerank/conf/schema.xml
@@ -911,7 +911,7 @@
           This value marks a document/node as updated.
     -->
     <field name="LATEST_APPLIED_CONTENT_VERSION_ID" type="long_without_precision_step"/>
-    <field name="LAST_INCOMING_CONTENT_VERSION_ID" type="long_without_precision_step" default="-10"/>
+    <field name="LAST_INCOMING_CONTENT_VERSION_ID" type="long_without_precision_step"/>
 
     <!--
       Used to store the last transaction and acl transaction for real time get


### PR DESCRIPTION
This PR removes the default for the LAST_INCOMING_CONTENT_VERSION_ID field from the schema.xml. This default was superflous because:

- the field is set to that value in the `SolrInformationServer.addContentProperty` method when content indexing is enabled
- the field is not relevant at all for non-node index documents (transactions, acls, states) and thus the default even causes skewed distribution values in the SOLR schema (when viewed in UI) and may cause higher storage costs for those index documents
