### PR TITLE
Reduce amount of /transaction calls in MetadataTracker in system without change if /nextTransaction is available

### DIFF
--- a/search-services/alfresco-search/src/main/java/org/alfresco/solr/tracker/MetadataTracker.java
+++ b/search-services/alfresco-search/src/main/java/org/alfresco/solr/tracker/MetadataTracker.java
@@ -789,6 +789,13 @@ public class MetadataTracker extends ActivatableTracker
                             Thread.currentThread().getId(), coreName, startTime, nextTxCommitTime);
                     transactions = client.getTransactions(nextTxCommitTime, null,
                             nextTxCommitTime + timeStep, null, maxResults);
+                    // advance for next iteration in case alreadyFoundTransactions() yields true
+                    startTime = nextTxCommitTime + timeStep;
+                }
+                else
+                {
+                    // no point in additional iterations when there is no newer transaction
+                    break;
                 }
             }
 


### PR DESCRIPTION
This PR reduces the overhead in polling for new transactions to index when a system is mostly read-only / without changes for a long time. This is something I had already noticed myself in production systems, but came about as a result of [a question in the Alfresco forum](https://connect.hyland.com/t5/alfresco-forum/search-service-is-calling-transaction-api-100-times-per-second/td-p/484688). In essence, the longer a system is without a change, the more calls the MetadataTracker executes against the /transactions (and /nextTransaction if available) endpoint of the Repository as it looks for any transaction to index.

This PR adds missing logic to stop the loop to incrementally scan the transaction table when the nextTransaction endpoint is available and returns a value indicating that no newer transaction exists at all. It also adjusts the startTime for the next iteration if a next transaction commit time is available but the transactions return in the subsequent call to the transactions endpoint where somehow already "found" before.

A similar issue exists with the ACL tracker. This also executes an increasing amount of calls to look for newer change sets in any system where no ACL changes are performed for a long time. Since there is no endpoint to find the next commit time for an ACL change set based on the last commit time, the overhead there cannot currently be improved in the same way as in the MetadataTracker.